### PR TITLE
Alternate fix for settings.py for Python 3

### DIFF
--- a/pxr/usdImaging/usdviewq/settings.py
+++ b/pxr/usdImaging/usdviewq/settings.py
@@ -80,8 +80,13 @@ class Settings(dict):
         if self._ephemeral:
             return
         try:
-            f = open(self._filename, "wb")
-            dump(self, f)
+            f = open(self._filename, "w")
+
+            # Explicly specify protocol 0 for cPickle/pickle.dump
+            # to maintain backwards compatibility. In Python 2
+            # protocol 0 was the default for cPickle.dump, but
+            # this changed in Python 3.
+            dump(self, f, protocol = 0)
             f.close()
         except:
             if ignoreErrors:
@@ -95,7 +100,7 @@ class Settings(dict):
         if self._ephemeral:
             return
         try:
-            f = open(self._filename, "rb")
+            f = open(self._filename, "r")
             self.update(load(f))
             f.close()
 


### PR DESCRIPTION
Force use of protocol 0 for pickling and revert
change to open files in binary mode to maintain
backwards compatibility with state files written
in Python 2.