### PR TITLE
Fix boost_python build error for boost 1.67+

### DIFF
--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -48,16 +48,32 @@ if(PXR_ENABLE_PYTHON_SUPPORT)
         find_package(PythonLibs 2.7 REQUIRED)
     endif()
 
-    # if boost >= 1.67
-    set(BOOST_PYTHON_COMPONENT_NAME "python") #${PYTHON_VERSION_NODOT}")
-
     # --Boost
     find_package(Boost
         COMPONENTS
             program_options
-            ${BOOST_PYTHON_COMPONENT_NAME}
-        REQUIRED
-    )
+        REQUIRED)
+
+    if (${Boost_VERSION_STRING} VERSION_GREATER_EQUAL "1.67")
+        # As of boost 1.67 the boost_python component name includes the
+        # associated Python version (e.g. python27, python36). Find the
+        # component under the versioned name and then set the generic
+        # Boost_PYTHON_LIBRARY variable so that we don't have to duplicate
+        # this logic in each library's CMakeLists.txt.
+        set(python_version_nodot "${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")
+        find_package(Boost
+            COMPONENTS
+                python${python_version_nodot}
+            REQUIRED
+        )
+        set(Boost_PYTHON_LIBRARY "${Boost_PYTHON${python_version_nodot}_LIBRARY}")
+    else()
+        find_package(Boost
+            COMPONENTS
+                python
+            REQUIRED
+        )
+    endif()
 
     # --Jinja2
     find_package(Jinja2)


### PR DESCRIPTION
The library name for boost_python is suffixed with
the associated version of Python as of boost 1.67.
This change updates the build system to detect
the boost version and use the appropriate component
name.
