### PR TITLE
Add entry point to flatten/deindex mesh buffers

### DIFF
--- a/pxr/usdImaging/hydraPassthrough/CMakeLists.txt
+++ b/pxr/usdImaging/hydraPassthrough/CMakeLists.txt
@@ -35,6 +35,7 @@ pxr_library(hydraPassthrough
         material
         materialParam
         mesh
+        meshPackagingUtil
         meshTopology
         meshUtil
         normalComputations

--- a/pxr/usdImaging/hydraPassthrough/meshPackagingUtil.cpp
+++ b/pxr/usdImaging/hydraPassthrough/meshPackagingUtil.cpp
@@ -1,0 +1,273 @@
+#include "meshPackagingUtil.h"
+
+#include "pxr/imaging/hd/meshUtil.h"
+
+#include "pxr/base/vt/value.h"
+#include "pxr/base/vt/visitValue.h"
+#include "pxr/base/vt/typeHeaders.h"
+
+#include <numeric>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+namespace {
+
+// Gathers array elements: result[i] = array[cornerIndices[i]].
+//
+// Returns an empty VtValue if the value is not an array or an index is
+// out of range.
+struct _GatherElementsVisitor {
+    const VtIntArray& cornerIndices;
+
+    template <typename T>
+    VtValue operator()(const VtArray<T>& array) const {
+        const int numElements = (int)array.size();
+        VtArray<T> result(cornerIndices.size());
+        T* dst = result.data();
+        const T* src = array.cdata();
+        for (size_t i = 0; i < cornerIndices.size(); ++i) {
+            const int index = cornerIndices[i];
+            if (index < 0 || index >= numElements) {
+                return VtValue();
+            }
+            dst[i] = src[index];
+        }
+        return VtValue(result);
+    }
+
+    // Fallback for non-array values, which cannot be gathered.
+    VtValue operator()(const VtValue& value) const {
+        return VtValue();
+    }
+};
+
+VtValue
+_GatherElements(const VtValue& value, const VtIntArray& cornerIndices)
+{
+    return VtVisitValue(value, _GatherElementsVisitor{cornerIndices});
+}
+
+// Flattens a face-varying channel's index buffer (one entry per refined
+// patch) into one index per corner of the mesh's faceVertexIndices buffer.
+bool
+_FlattenFvarIndices(
+    const VtValue& indices,
+    size_t numCorners,
+    VtIntArray* flattened)
+{
+    if (indices.IsHolding<VtArray<GfVec3i>>()) {
+        // Triangle patches (loop scheme) map 1:1 onto the triangle list.
+        const VtArray<GfVec3i>& tris = indices.UncheckedGet<VtArray<GfVec3i>>();
+        if (tris.size() * 3 != numCorners) {
+            return false;
+        }
+        flattened->resize(numCorners);
+        int* dst = flattened->data();
+        for (const GfVec3i& tri : tris) {
+            *dst++ = tri[0];
+            *dst++ = tri[1];
+            *dst++ = tri[2];
+        }
+        return true;
+    }
+    if (indices.IsHolding<VtArray<GfVec4i>>()) {
+        // Quad patches (catmark/bilinear schemes). The mesh's index buffer
+        // was emitted by HdMeshTriQuadBuilder, which splits each quad into
+        // the triangles (0,1,2) and (2,3,0); apply the same split here so
+        // the corners line up.
+        const VtArray<GfVec4i>& quads = indices.UncheckedGet<VtArray<GfVec4i>>();
+        if (quads.size() * 6 != numCorners) {
+            return false;
+        }
+        flattened->resize(numCorners);
+        int* dst = flattened->data();
+        for (const GfVec4i& quad : quads) {
+            *dst++ = quad[0];
+            *dst++ = quad[1];
+            *dst++ = quad[2];
+            *dst++ = quad[2];
+            *dst++ = quad[3];
+            *dst++ = quad[0];
+        }
+        return true;
+    }
+    // Adaptive refinement (bspline/box spline patches) is not supported.
+    return false;
+}
+
+// Builds one coarse-face index per corner so uniform (per-face) primvars
+// can be expanded. primitiveParam has one entry per triangle for unrefined
+// meshes (int) and one entry per patch for refined meshes (GfVec3i with
+// the encoded param in element [0]). The number of corners per entry
+// (3 for triangles, 6 for triangulated quads) falls out of the buffer
+// sizes.
+bool
+_BuildUniformCornerIndices(
+    const VtValue& primitiveParam,
+    size_t numCorners,
+    VtIntArray* cornerIndices)
+{
+    VtIntArray encodedParams;
+    if (primitiveParam.IsHolding<VtIntArray>()) {
+        encodedParams = primitiveParam.UncheckedGet<VtIntArray>();
+    } else if (primitiveParam.IsHolding<VtArray<GfVec3i>>()) {
+        const VtArray<GfVec3i>& params =
+            primitiveParam.UncheckedGet<VtArray<GfVec3i>>();
+        encodedParams.resize(params.size());
+        for (size_t i = 0; i < params.size(); ++i) {
+            encodedParams[i] = params[i][0];
+        }
+    } else {
+        return false;
+    }
+
+    if (encodedParams.empty() || numCorners % encodedParams.size() != 0) {
+        return false;
+    }
+    const size_t cornersPerEntry = numCorners / encodedParams.size();
+    if (cornersPerEntry != 3 && cornersPerEntry != 6) {
+        return false;
+    }
+
+    cornerIndices->resize(numCorners);
+    int* dst = cornerIndices->data();
+    for (const int encodedParam : encodedParams) {
+        const int faceIndex =
+            HdMeshUtil::DecodeFaceIndexFromCoarseFaceParam(encodedParam);
+        for (size_t corner = 0; corner < cornersPerEntry; ++corner) {
+            *dst++ = faceIndex;
+        }
+    }
+    return true;
+}
+
+} // anonymous namespace
+
+namespace HydraPassthroughMeshPackagingUtil
+{
+
+void
+DeindexMesh(HydraPassthroughRenderData::MeshData* meshData)
+{
+    // Keep a copy of the original vertex indices; they are overwritten at
+    // the end.
+    const VtIntArray vertexIndices = meshData->faceVertexIndices;
+    const size_t numCorners = vertexIndices.size();
+    if (numCorners == 0) {
+        return;
+    }
+
+    // Refined face-varying primvars hold compact value buffers that their
+    // channel's index buffer maps onto corners; expand them through those
+    // indices. Unrefined face-varying primvars have no channel and are
+    // already per-corner.
+    for (const HydraPassthroughRenderData::FaceVaryingChannel& channel :
+            meshData->faceVaryingChannels) {
+        VtIntArray cornerIndices;
+        if (!_FlattenFvarIndices(channel.indices, numCorners,
+                                 &cornerIndices)) {
+            TF_WARN("Face-varying channel %d of %s has indices that don't "
+                    "match the mesh's triangulated topology; leaving its "
+                    "primvars unexpanded",
+                    channel.channel, meshData->id.GetText());
+            continue;
+        }
+        for (const TfToken& name : channel.primvars) {
+            auto primvarIt = meshData->primvars.find(name);
+            if (primvarIt == meshData->primvars.end()) {
+                continue;
+            }
+            const VtValue expanded =
+                _GatherElements(primvarIt->second.data, cornerIndices);
+            if (expanded.IsEmpty()) {
+                TF_WARN("Could not expand face-varying primvar %s of %s",
+                        name.GetText(), meshData->id.GetText());
+                continue;
+            }
+            primvarIt->second.data = expanded;
+        }
+    }
+    meshData->faceVaryingChannels.clear();
+
+    // Built on demand if we encounter a uniform primvar.
+    VtIntArray uniformCornerIndices;
+    bool builtUniformCornerIndices = false;
+
+    for (auto& primvarEntry : meshData->primvars) {
+        const TfToken& name = primvarEntry.first;
+        HydraPassthroughRenderData::PrimvarData& primvar =
+            primvarEntry.second;
+
+        switch (primvar.interpolation) {
+            case HdInterpolationVertex:
+            case HdInterpolationVarying: {
+                const VtValue expanded =
+                    _GatherElements(primvar.data, vertexIndices);
+                if (expanded.IsEmpty()) {
+                    TF_WARN("Could not expand vertex/varying primvar %s of %s",
+                            name.GetText(), meshData->id.GetText());
+                    break;
+                }
+                primvar.data = expanded;
+                primvar.interpolation = HdInterpolationFaceVarying;
+                break;
+            }
+            case HdInterpolationUniform: {
+                if (!builtUniformCornerIndices) {
+                    builtUniformCornerIndices = true;
+                    if (!_BuildUniformCornerIndices(
+                            meshData->primitiveParam, numCorners,
+                            &uniformCornerIndices)) {
+                        TF_WARN("Could not map faces to corners for %s; "
+                                "leaving uniform primvars unexpanded",
+                                meshData->id.GetText());
+                    }
+                }
+                if (uniformCornerIndices.empty()) {
+                    break;
+                }
+                const VtValue expanded =
+                    _GatherElements(primvar.data, uniformCornerIndices);
+                if (expanded.IsEmpty()) {
+                    TF_WARN("Could not expand uniform primvar %s of %s",
+                            name.GetText(), meshData->id.GetText());
+                    break;
+                }
+                primvar.data = expanded;
+                primvar.interpolation = HdInterpolationFaceVarying;
+                break;
+            }
+            case HdInterpolationFaceVarying: {
+                // Already one value per corner; just sanity check.
+                if (primvar.data.GetArraySize() != numCorners) {
+                    TF_WARN("Face-varying primvar %s of %s has %zu values, "
+                            "expected %zu",
+                            name.GetText(), meshData->id.GetText(),
+                            primvar.data.GetArraySize(), numCorners);
+                }
+                break;
+            }
+            default:
+                // Constant and other interpolations are unaffected.
+                break;
+        }
+    }
+
+    // The points member mirrors the points primvar; keep them consistent.
+    if (!meshData->points.IsEmpty()) {
+        const VtValue expanded =
+            _GatherElements(meshData->points, vertexIndices);
+        if (!expanded.IsEmpty()) {
+            meshData->points = expanded;
+        }
+    }
+
+    // Every buffer is per-corner now, so the indices become the identity.
+    VtIntArray identity(numCorners);
+    std::iota(identity.begin(), identity.end(), 0);
+    meshData->faceVertexIndices = identity;
+}
+
+} // namespace HydraPassthroughMeshPackagingUtil
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usdImaging/hydraPassthrough/meshPackagingUtil.cpp
+++ b/pxr/usdImaging/hydraPassthrough/meshPackagingUtil.cpp
@@ -6,7 +6,12 @@
 #include "pxr/base/vt/visitValue.h"
 #include "pxr/base/vt/typeHeaders.h"
 
+#include <algorithm>
 #include <numeric>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <vector>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -141,6 +146,58 @@ _BuildUniformCornerIndices(
     return true;
 }
 
+// Builds a per-element "first occurrence" index column for an array value:
+// elements that are bitwise equal map to the index of their first
+// occurrence. Welding uses this to detect where per-corner values agree
+// exactly.
+//
+// Bitwise comparison means the result is always correct: it can only ever
+// split more vertices than strictly needed, never weld values that differ.
+// Element types that are not trivially copyable fall back to the identity
+// column (every corner unique), and non-array values produce an empty
+// column.
+struct _BuildFirstOccurrenceColumnVisitor {
+    template <typename T>
+    VtIntArray operator()(const VtArray<T>& array) const {
+        VtIntArray column(array.size());
+        if constexpr (std::is_trivially_copyable_v<T>) {
+            // Note: element types with internal padding could produce
+            // false splits here, but the arithmetic and Gf types used for
+            // primvars have none.
+            const T* src = array.cdata();
+            std::unordered_map<std::string, int> firstOccurrence;
+            firstOccurrence.reserve(array.size());
+            int* dst = column.data();
+            for (size_t i = 0; i < array.size(); ++i) {
+                const std::string bytes(
+                    reinterpret_cast<const char*>(src + i), sizeof(T));
+                const auto insertion = firstOccurrence.emplace(bytes, (int)i);
+                dst[i] = insertion.first->second;
+            }
+        } else {
+            std::iota(column.begin(), column.end(), 0);
+        }
+        return column;
+    }
+
+    // Fallback for non-array values, which have no elements to weld.
+    VtIntArray operator()(const VtValue& value) const {
+        return VtIntArray();
+    }
+};
+
+// Hash for a weld key (one index per column).
+struct _CornerKeyHash {
+    size_t operator()(const std::vector<int>& key) const {
+        size_t hash = 0;
+        for (const int value : key) {
+            hash ^= std::hash<int>()(value) +
+                    0x9e3779b9 + (hash << 6) + (hash >> 2);
+        }
+        return hash;
+    }
+};
+
 } // anonymous namespace
 
 namespace HydraPassthroughMeshPackagingUtil
@@ -266,6 +323,179 @@ DeindexMesh(HydraPassthroughRenderData::MeshData* meshData)
     VtIntArray identity(numCorners);
     std::iota(identity.begin(), identity.end(), 0);
     meshData->faceVertexIndices = identity;
+}
+
+void
+WeldMesh(HydraPassthroughRenderData::MeshData* meshData)
+{
+    const VtIntArray vertexIndices = meshData->faceVertexIndices;
+    const size_t numCorners = vertexIndices.size();
+    if (numCorners == 0) {
+        return;
+    }
+
+    // Each column maps corners to indices into some source value array.
+    // Together the columns form the weld key of a corner: two corners weld
+    // into one output vertex only if every column agrees.
+    struct _Column {
+        VtIntArray cornerIndices;
+        // The primvars whose data the cornerIndices index into.
+        std::vector<TfToken> primvars;
+    };
+    std::vector<_Column> columns;
+
+    // The vertex column drives points and the vertex/varying primvars.
+    // It is always present, so corners on different vertices never weld.
+    const size_t vertexColumn = 0;
+    columns.push_back({vertexIndices, {}});
+
+    // Sort the primvars into the column layout by interpolation.
+    std::vector<TfToken> fvarPrimvars;
+    std::vector<TfToken> uniformPrimvars;
+    for (const auto& primvarEntry : meshData->primvars) {
+        switch (primvarEntry.second.interpolation) {
+            case HdInterpolationVertex:
+            case HdInterpolationVarying:
+                columns[vertexColumn].primvars.push_back(primvarEntry.first);
+                break;
+            case HdInterpolationFaceVarying:
+                fvarPrimvars.push_back(primvarEntry.first);
+                break;
+            case HdInterpolationUniform:
+                uniformPrimvars.push_back(primvarEntry.first);
+                break;
+            default:
+                // Constant and other interpolations are unaffected.
+                break;
+        }
+    }
+
+    // Refined face-varying primvars weld by their channel's indices, which
+    // map corners into the compact value buffers.
+    for (const HydraPassthroughRenderData::FaceVaryingChannel& channel :
+            meshData->faceVaryingChannels) {
+        _Column column;
+        const bool validIndices = _FlattenFvarIndices(
+            channel.indices, numCorners, &column.cornerIndices);
+        if (!validIndices) {
+            TF_WARN("Face-varying channel %d of %s has indices that don't "
+                    "match the mesh's triangulated topology; leaving its "
+                    "primvars unwelded",
+                    channel.channel, meshData->id.GetText());
+        }
+        for (const TfToken& name : channel.primvars) {
+            // Channel primvars are not per-corner, so exclude them from the
+            // per-corner handling below whether or not we can weld them.
+            const auto namePos =
+                std::find(fvarPrimvars.begin(), fvarPrimvars.end(), name);
+            if (namePos == fvarPrimvars.end()) {
+                continue;
+            }
+            fvarPrimvars.erase(namePos);
+            if (validIndices) {
+                column.primvars.push_back(name);
+            }
+        }
+        if (!column.primvars.empty()) {
+            columns.push_back(std::move(column));
+        }
+    }
+
+    // Unrefined face-varying primvars are already per-corner; weld them on
+    // exact value equality.
+    for (const TfToken& name : fvarPrimvars) {
+        const HydraPassthroughRenderData::PrimvarData& primvar =
+            meshData->primvars.find(name)->second;
+        if (primvar.data.GetArraySize() != numCorners) {
+            TF_WARN("Face-varying primvar %s of %s has %zu values, "
+                    "expected %zu; leaving it unwelded",
+                    name.GetText(), meshData->id.GetText(),
+                    primvar.data.GetArraySize(), numCorners);
+            continue;
+        }
+        VtIntArray column = VtVisitValue(
+            primvar.data, _BuildFirstOccurrenceColumnVisitor());
+        if (column.size() != numCorners) {
+            TF_WARN("Could not weld face-varying primvar %s of %s",
+                    name.GetText(), meshData->id.GetText());
+            continue;
+        }
+        columns.push_back({std::move(column), {name}});
+    }
+
+    // Uniform primvars share one coarse-face column.
+    if (!uniformPrimvars.empty()) {
+        _Column column;
+        if (_BuildUniformCornerIndices(meshData->primitiveParam, numCorners,
+                                       &column.cornerIndices)) {
+            column.primvars = std::move(uniformPrimvars);
+            columns.push_back(std::move(column));
+        } else {
+            TF_WARN("Could not map faces to corners for %s; leaving uniform "
+                    "primvars unwelded",
+                    meshData->id.GetText());
+        }
+    }
+
+    // Weld: assign an output vertex to each distinct weld key, in order of
+    // first occurrence, and rewrite the index buffer.
+    std::unordered_map<std::vector<int>, int, _CornerKeyHash> outputVertexIds;
+    outputVertexIds.reserve(numCorners);
+    VtIntArray newIndices(numCorners);
+    std::vector<int> representativeCorners;
+    representativeCorners.reserve(numCorners);
+    std::vector<int> key(columns.size());
+    for (size_t corner = 0; corner < numCorners; ++corner) {
+        for (size_t i = 0; i < columns.size(); ++i) {
+            key[i] = columns[i].cornerIndices.cdata()[corner];
+        }
+        const auto insertion = outputVertexIds.emplace(
+            key, (int)representativeCorners.size());
+        if (insertion.second) {
+            representativeCorners.push_back((int)corner);
+        }
+        newIndices[corner] = insertion.first->second;
+    }
+    const size_t numOutputVertices = representativeCorners.size();
+
+    // Rebuild each column's primvars with one value per output vertex,
+    // gathered through the column at each vertex's representative corner.
+    for (size_t columnIndex = 0; columnIndex < columns.size(); ++columnIndex) {
+        const _Column& column = columns[columnIndex];
+
+        VtIntArray remap(numOutputVertices);
+        const int* cornerIndicesData = column.cornerIndices.cdata();
+        for (size_t vertex = 0; vertex < numOutputVertices; ++vertex) {
+            remap[vertex] = cornerIndicesData[representativeCorners[vertex]];
+        }
+
+        for (const TfToken& name : column.primvars) {
+            HydraPassthroughRenderData::PrimvarData& primvar =
+                meshData->primvars.find(name)->second;
+            const VtValue welded = _GatherElements(primvar.data, remap);
+            if (welded.IsEmpty()) {
+                TF_WARN("Could not weld primvar %s of %s",
+                        name.GetText(), meshData->id.GetText());
+                continue;
+            }
+            primvar.data = welded;
+            // The data is now parallel to points and addressed by
+            // faceVertexIndices, which is vertex interpolation.
+            primvar.interpolation = HdInterpolationVertex;
+        }
+
+        // The points member mirrors the points primvar; keep them
+        // consistent.
+        if (columnIndex == vertexColumn && !meshData->points.IsEmpty()) {
+            const VtValue welded = _GatherElements(meshData->points, remap);
+            if (!welded.IsEmpty()) {
+                meshData->points = welded;
+            }
+        }
+    }
+
+    meshData->faceVertexIndices = newIndices;
+    meshData->faceVaryingChannels.clear();
 }
 
 } // namespace HydraPassthroughMeshPackagingUtil

--- a/pxr/usdImaging/hydraPassthrough/meshPackagingUtil.h
+++ b/pxr/usdImaging/hydraPassthrough/meshPackagingUtil.h
@@ -16,6 +16,26 @@ namespace HydraPassthroughMeshPackagingUtil
     void
     DeindexMesh(HydraPassthroughRenderData::MeshData* meshData);
 
+    /// Rewrites the mesh into a single-index layout: every non-constant
+    /// primvar, along with the points, holds one value per output vertex,
+    /// all addressed by the shared faceVertexIndices buffer.
+    ///
+    /// Corners weld into one output vertex only where all of their
+    /// attributes agree: positions and vertex/varying primvars by vertex
+    /// index, refined face-varying primvars by their channel indices,
+    /// unrefined face-varying primvars by exact bitwise value equality
+    /// (no epsilon), and uniform primvars by source face. Vertices
+    /// therefore stay shared everywhere except across genuine seams.
+    ///
+    /// This produces the same renderer-facing contract as DeindexMesh
+    /// (single index buffer, expanded primvars parallel to points) but
+    /// with the minimal vertex count; DeindexMesh is its worst case and
+    /// is kept as the simple reference implementation. Expanded primvars
+    /// report vertex interpolation, since they are indexed alongside the
+    /// points.
+    void
+    WeldMesh(HydraPassthroughRenderData::MeshData* meshData);
+
 } // namespace HydraPassthroughMeshPackagingUtil
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usdImaging/hydraPassthrough/meshPackagingUtil.h
+++ b/pxr/usdImaging/hydraPassthrough/meshPackagingUtil.h
@@ -1,0 +1,23 @@
+#ifndef PXR_USD_IMAGING_HYDRA_PASSTHROUGH_MESH_PACKAGING_UTIL_H
+#define PXR_USD_IMAGING_HYDRA_PASSTHROUGH_MESH_PACKAGING_UTIL_H
+
+#include "pxr/pxr.h"
+
+#include "pxr/usdImaging/hydraPassthrough/renderData.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+namespace HydraPassthroughMeshPackagingUtil
+{
+    /// Rewrites the mesh so that every non-constant primvar holds one value per
+    /// corner of faceVertexIndices, in corner order, and faceVertexIndices
+    /// becomes the identity. The result needs only a single (trivial) index
+    /// buffer, which is what renderers without multi-index support consume.
+    void
+    DeindexMesh(HydraPassthroughRenderData::MeshData* meshData);
+
+} // namespace HydraPassthroughMeshPackagingUtil
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // PXR_USD_IMAGING_HYDRA_PASSTHROUGH_MESH_PACKAGING_UTIL_H

--- a/pxr/usdImaging/hydraPassthrough/meshUtil.cpp
+++ b/pxr/usdImaging/hydraPassthrough/meshUtil.cpp
@@ -102,7 +102,10 @@ _QuadrangulateFaceVaryingPrimvar(
     HdBufferSourceSharedPtr quadSource =
         topology->GetQuadrangulateFaceVaryingComputation(source, id);
 
-    resourceRegistry->AddPrimvarSource(id, source, HdInterpolationFaceVarying);
+    // The coarse source is registered only so it resolves for the
+    // quadrangulation computation; the computation's output replaces it.
+    resourceRegistry->AddPrimvarSource(id, source, HdInterpolationFaceVarying,
+                                       /*isIntermediate=*/true);
 
     return quadSource;
 }
@@ -116,7 +119,10 @@ _TriangulateFaceVaryingPrimvar(HdBufferSourceSharedPtr const &source,
     HdBufferSourceSharedPtr triSource =
         topology->GetTriangulateFaceVaryingComputation(source, id);
 
-    resourceRegistry->AddPrimvarSource(id, source, HdInterpolationFaceVarying);
+    // The coarse source is registered only so it resolves for the
+    // triangulation computation; the computation's output replaces it.
+    resourceRegistry->AddPrimvarSource(id, source, HdInterpolationFaceVarying,
+                                       /*isIntermediate=*/true);
 
     return triSource;
 }
@@ -323,8 +329,12 @@ void PopulateMeshTopology(
     TfToken fvarLinearInterpRule =
         finalTopology->GetSubdivTags().GetFaceVaryingInterpolationRule();
 
-    if ((refineLevel > 0) && 
-        (fvarLinearInterpRule != PxOsdOpenSubdivTokens->all) && 
+    // Face-varying channels and their index buffers only exist for refined
+    // (subdivided) meshes. For refineLevel 0 the face-varying primvars are
+    // triangulated into flattened per-corner buffers instead, and need no
+    // topology tracking. This matches HdStMesh::_PopulateTopology.
+    if ((refineLevel > 0) &&
+        (fvarLinearInterpRule != PxOsdOpenSubdivTokens->all) &&
         updatePrimvars) {
 
         _GatherFaceVaryingTopologies(
@@ -598,12 +608,22 @@ PopulateVertexAndVaryingPrimvars(
     // schedule buffer sources
     if (!sources.empty()) {
         // add sources to update queue
+        //
+        // Note that sources also holds ext computation sources and skips
+        // primvars that were not dirty, so the partition index can exceed
+        // what actually landed in sources; clamp so the split stays valid.
+        const size_t splitPos =
+            std::min(sources.size(), size_t(vertexPartitionIndex) + 1);
         HdBufferSourceSharedPtrVector vertexSources(
-            sources.begin(), sources.begin() + vertexPartitionIndex + 1);
+            sources.begin(), sources.begin() + splitPos);
         HdBufferSourceSharedPtrVector varyingSources(
-            sources.begin() + vertexPartitionIndex + 1, sources.end());
-        resourceRegistry->AddPrimvarSources(id, std::move(vertexSources), HdInterpolationVertex);
-        resourceRegistry->AddPrimvarSources(id, std::move(varyingSources), HdInterpolationVarying);
+            sources.begin() + splitPos, sources.end());
+        if (!vertexSources.empty()) {
+            resourceRegistry->AddPrimvarSources(id, std::move(vertexSources), HdInterpolationVertex);
+        }
+        if (!varyingSources.empty()) {
+            resourceRegistry->AddPrimvarSources(id, std::move(varyingSources), HdInterpolationVarying);
+        }
     }
 
     // Can't currently schedule computations

--- a/pxr/usdImaging/hydraPassthrough/renderData.cpp
+++ b/pxr/usdImaging/hydraPassthrough/renderData.cpp
@@ -3,18 +3,14 @@
 #include "pxr/usdImaging/hydraPassthrough/constantVtBufferSource.h"
 #include "pxr/usdImaging/hydraPassthrough/fvarTopologyTracker.h"
 #include "pxr/usdImaging/hydraPassthrough/hdTypeUtil.h"
+#include "pxr/usdImaging/hydraPassthrough/meshPackagingUtil.h"
 #include "pxr/usdImaging/hydraPassthrough/subdivision.h"
 
 #include "pxr/base/tf/diagnosticLite.h"
 #include "pxr/imaging/hd/camera.h"
-#include "pxr/imaging/hd/meshUtil.h"
 #include "pxr/imaging/hd/vtBufferSource.h"
 
-#include "pxr/base/gf/vec3i.h"
-#include "pxr/base/gf/vec4i.h"
 #include "pxr/base/vt/value.h"
-#include "pxr/base/vt/visitValue.h"
-#include "pxr/base/vt/typeHeaders.h"
 
 #include <numeric>
 
@@ -22,6 +18,7 @@
 PXR_NAMESPACE_OPEN_SCOPE
 
 namespace HdTypeUtil = HydraPassthroughHdTypeUtil;
+namespace PackagingUtil = HydraPassthroughMeshPackagingUtil;
 
 const HydraPassthroughRenderData::MeshData*
 HydraPassthroughRenderData::RenderData::GetMesh(const SdfPath& id) const {
@@ -384,270 +381,11 @@ HydraPassthroughRenderData::ExtractRenderDataCopy() const {
     return _renderData;
 }
 
-namespace {
-
-// Gathers array elements: result[i] = array[cornerIndices[i]].
-//
-// Returns an empty VtValue if the value is not an array or an index is
-// out of range.
-struct _GatherElementsVisitor {
-    const VtIntArray& cornerIndices;
-
-    template <typename T>
-    VtValue operator()(const VtArray<T>& array) const {
-        const int numElements = (int)array.size();
-        VtArray<T> result(cornerIndices.size());
-        T* dst = result.data();
-        const T* src = array.cdata();
-        for (size_t i = 0; i < cornerIndices.size(); ++i) {
-            const int index = cornerIndices[i];
-            if (index < 0 || index >= numElements) {
-                return VtValue();
-            }
-            dst[i] = src[index];
-        }
-        return VtValue(result);
-    }
-
-    // Fallback for non-array values, which cannot be gathered.
-    VtValue operator()(const VtValue& value) const {
-        return VtValue();
-    }
-};
-
-VtValue
-_GatherElements(const VtValue& value, const VtIntArray& cornerIndices)
-{
-    return VtVisitValue(value, _GatherElementsVisitor{cornerIndices});
-}
-
-// Flattens a face-varying channel's index buffer (one entry per refined
-// patch) into one index per corner of the mesh's faceVertexIndices buffer.
-bool
-_FlattenFvarIndices(
-    const VtValue& indices,
-    size_t numCorners,
-    VtIntArray* flattened)
-{
-    if (indices.IsHolding<VtArray<GfVec3i>>()) {
-        // Triangle patches (loop scheme) map 1:1 onto the triangle list.
-        const VtArray<GfVec3i>& tris = indices.UncheckedGet<VtArray<GfVec3i>>();
-        if (tris.size() * 3 != numCorners) {
-            return false;
-        }
-        flattened->resize(numCorners);
-        int* dst = flattened->data();
-        for (const GfVec3i& tri : tris) {
-            *dst++ = tri[0];
-            *dst++ = tri[1];
-            *dst++ = tri[2];
-        }
-        return true;
-    }
-    if (indices.IsHolding<VtArray<GfVec4i>>()) {
-        // Quad patches (catmark/bilinear schemes). The mesh's index buffer
-        // was emitted by HdMeshTriQuadBuilder, which splits each quad into
-        // the triangles (0,1,2) and (2,3,0); apply the same split here so
-        // the corners line up.
-        const VtArray<GfVec4i>& quads = indices.UncheckedGet<VtArray<GfVec4i>>();
-        if (quads.size() * 6 != numCorners) {
-            return false;
-        }
-        flattened->resize(numCorners);
-        int* dst = flattened->data();
-        for (const GfVec4i& quad : quads) {
-            *dst++ = quad[0];
-            *dst++ = quad[1];
-            *dst++ = quad[2];
-            *dst++ = quad[2];
-            *dst++ = quad[3];
-            *dst++ = quad[0];
-        }
-        return true;
-    }
-    // Adaptive refinement (bspline/box spline patches) is not supported.
-    return false;
-}
-
-// Builds one coarse-face index per corner so uniform (per-face) primvars
-// can be expanded. primitiveParam has one entry per triangle for unrefined
-// meshes (int) and one entry per patch for refined meshes (GfVec3i with
-// the encoded param in element [0]). The number of corners per entry
-// (3 for triangles, 6 for triangulated quads) falls out of the buffer
-// sizes.
-bool
-_BuildUniformCornerIndices(
-    const VtValue& primitiveParam,
-    size_t numCorners,
-    VtIntArray* cornerIndices)
-{
-    VtIntArray encodedParams;
-    if (primitiveParam.IsHolding<VtIntArray>()) {
-        encodedParams = primitiveParam.UncheckedGet<VtIntArray>();
-    } else if (primitiveParam.IsHolding<VtArray<GfVec3i>>()) {
-        const VtArray<GfVec3i>& params =
-            primitiveParam.UncheckedGet<VtArray<GfVec3i>>();
-        encodedParams.resize(params.size());
-        for (size_t i = 0; i < params.size(); ++i) {
-            encodedParams[i] = params[i][0];
-        }
-    } else {
-        return false;
-    }
-
-    if (encodedParams.empty() || numCorners % encodedParams.size() != 0) {
-        return false;
-    }
-    const size_t cornersPerEntry = numCorners / encodedParams.size();
-    if (cornersPerEntry != 3 && cornersPerEntry != 6) {
-        return false;
-    }
-
-    cornerIndices->resize(numCorners);
-    int* dst = cornerIndices->data();
-    for (const int encodedParam : encodedParams) {
-        const int faceIndex =
-            HdMeshUtil::DecodeFaceIndexFromCoarseFaceParam(encodedParam);
-        for (size_t corner = 0; corner < cornersPerEntry; ++corner) {
-            *dst++ = faceIndex;
-        }
-    }
-    return true;
-}
-
-// Rewrites the mesh so that every non-constant primvar holds one value per
-// corner of faceVertexIndices, in corner order, and faceVertexIndices
-// becomes the identity. The result needs only a single (trivial) index
-// buffer, which is what renderers without multi-index support consume.
-void
-_DeindexMesh(HydraPassthroughRenderData::MeshData* meshData)
-{
-    // Keep a copy of the original vertex indices; they are overwritten at
-    // the end.
-    const VtIntArray vertexIndices = meshData->faceVertexIndices;
-    const size_t numCorners = vertexIndices.size();
-    if (numCorners == 0) {
-        return;
-    }
-
-    // Refined face-varying primvars hold compact value buffers that their
-    // channel's index buffer maps onto corners; expand them through those
-    // indices. Unrefined face-varying primvars have no channel and are
-    // already per-corner.
-    for (const HydraPassthroughRenderData::FaceVaryingChannel& channel :
-            meshData->faceVaryingChannels) {
-        VtIntArray cornerIndices;
-        if (!_FlattenFvarIndices(channel.indices, numCorners,
-                                 &cornerIndices)) {
-            TF_WARN("Face-varying channel %d of %s has indices that don't "
-                    "match the mesh's triangulated topology; leaving its "
-                    "primvars unexpanded",
-                    channel.channel, meshData->id.GetText());
-            continue;
-        }
-        for (const TfToken& name : channel.primvars) {
-            auto primvarIt = meshData->primvars.find(name);
-            if (primvarIt == meshData->primvars.end()) {
-                continue;
-            }
-            const VtValue expanded =
-                _GatherElements(primvarIt->second.data, cornerIndices);
-            if (expanded.IsEmpty()) {
-                TF_WARN("Could not expand face-varying primvar %s of %s",
-                        name.GetText(), meshData->id.GetText());
-                continue;
-            }
-            primvarIt->second.data = expanded;
-        }
-    }
-    meshData->faceVaryingChannels.clear();
-
-    // Built on demand if we encounter a uniform primvar.
-    VtIntArray uniformCornerIndices;
-    bool builtUniformCornerIndices = false;
-
-    for (auto& primvarEntry : meshData->primvars) {
-        const TfToken& name = primvarEntry.first;
-        HydraPassthroughRenderData::PrimvarData& primvar =
-            primvarEntry.second;
-
-        switch (primvar.interpolation) {
-            case HdInterpolationVertex:
-            case HdInterpolationVarying: {
-                const VtValue expanded =
-                    _GatherElements(primvar.data, vertexIndices);
-                if (expanded.IsEmpty()) {
-                    TF_WARN("Could not expand vertex/varying primvar %s of %s",
-                            name.GetText(), meshData->id.GetText());
-                    break;
-                }
-                primvar.data = expanded;
-                primvar.interpolation = HdInterpolationFaceVarying;
-                break;
-            }
-            case HdInterpolationUniform: {
-                if (!builtUniformCornerIndices) {
-                    builtUniformCornerIndices = true;
-                    if (!_BuildUniformCornerIndices(
-                            meshData->primitiveParam, numCorners,
-                            &uniformCornerIndices)) {
-                        TF_WARN("Could not map faces to corners for %s; "
-                                "leaving uniform primvars unexpanded",
-                                meshData->id.GetText());
-                    }
-                }
-                if (uniformCornerIndices.empty()) {
-                    break;
-                }
-                const VtValue expanded =
-                    _GatherElements(primvar.data, uniformCornerIndices);
-                if (expanded.IsEmpty()) {
-                    TF_WARN("Could not expand uniform primvar %s of %s",
-                            name.GetText(), meshData->id.GetText());
-                    break;
-                }
-                primvar.data = expanded;
-                primvar.interpolation = HdInterpolationFaceVarying;
-                break;
-            }
-            case HdInterpolationFaceVarying: {
-                // Already one value per corner; just sanity check.
-                if (primvar.data.GetArraySize() != numCorners) {
-                    TF_WARN("Face-varying primvar %s of %s has %zu values, "
-                            "expected %zu",
-                            name.GetText(), meshData->id.GetText(),
-                            primvar.data.GetArraySize(), numCorners);
-                }
-                break;
-            }
-            default:
-                // Constant and other interpolations are unaffected.
-                break;
-        }
-    }
-
-    // The points member mirrors the points primvar; keep them consistent.
-    if (!meshData->points.IsEmpty()) {
-        const VtValue expanded =
-            _GatherElements(meshData->points, vertexIndices);
-        if (!expanded.IsEmpty()) {
-            meshData->points = expanded;
-        }
-    }
-
-    // Every buffer is per-corner now, so the indices become the identity.
-    VtIntArray identity(numCorners);
-    std::iota(identity.begin(), identity.end(), 0);
-    meshData->faceVertexIndices = identity;
-}
-
-} // anonymous namespace
-
 HydraPassthroughRenderData::RenderData
 HydraPassthroughRenderData::ExtractDeindexedRenderDataCopy() const {
     RenderData renderData = ExtractRenderDataCopy();
     for (auto& meshEntry : renderData.meshes) {
-        _DeindexMesh(&meshEntry.second);
+        PackagingUtil::DeindexMesh(&meshEntry.second);
     }
     return renderData;
 }

--- a/pxr/usdImaging/hydraPassthrough/renderData.cpp
+++ b/pxr/usdImaging/hydraPassthrough/renderData.cpp
@@ -7,9 +7,16 @@
 
 #include "pxr/base/tf/diagnosticLite.h"
 #include "pxr/imaging/hd/camera.h"
+#include "pxr/imaging/hd/meshUtil.h"
 #include "pxr/imaging/hd/vtBufferSource.h"
 
+#include "pxr/base/gf/vec3i.h"
+#include "pxr/base/gf/vec4i.h"
 #include "pxr/base/vt/value.h"
+#include "pxr/base/vt/visitValue.h"
+#include "pxr/base/vt/typeHeaders.h"
+
+#include <numeric>
 
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -189,7 +196,10 @@ static void _UpdateFaceVaryingChannels(HydraPassthroughRenderData::MeshData& mes
     // Find the channel for this primvar
     int channel = meshData.fvarTopologyTracker->GetChannelFromPrimvar(primvarName);
     if (channel < 0) {
-        TF_RUNTIME_ERROR("Primvar %s is marked as face varying but has no associated channel in the fvar topology tracker", primvarName.GetText());
+        // Face-varying channels only exist for refined (subdivided) meshes.
+        // For unrefined meshes the primvar buffer has already been
+        // triangulated into one value per corner of faceVertexIndices, in
+        // triangle order, so it needs no channel or index buffer.
         return;
     }
 
@@ -199,7 +209,8 @@ static void _UpdateFaceVaryingChannels(HydraPassthroughRenderData::MeshData& mes
     if (it == meshData.faceVaryingChannels.end()) {
         // Create new channel
         meshData.faceVaryingChannels.push_back({channel, {}, {primvarName}});
-    } else {
+    } else if (std::find(it->primvars.begin(), it->primvars.end(),
+                         primvarName) == it->primvars.end()) {
         // Add primvar to existing channel
         it->primvars.push_back(primvarName);
     }
@@ -371,6 +382,274 @@ HydraPassthroughRenderData::ExtractRenderDataCopy() const {
     const std::lock_guard<std::mutex> lock2(_cameraMutex);
     const std::lock_guard<std::mutex> lock3(_materialMutex);
     return _renderData;
+}
+
+namespace {
+
+// Gathers array elements: result[i] = array[cornerIndices[i]].
+//
+// Returns an empty VtValue if the value is not an array or an index is
+// out of range.
+struct _GatherElementsVisitor {
+    const VtIntArray& cornerIndices;
+
+    template <typename T>
+    VtValue operator()(const VtArray<T>& array) const {
+        const int numElements = (int)array.size();
+        VtArray<T> result(cornerIndices.size());
+        T* dst = result.data();
+        const T* src = array.cdata();
+        for (size_t i = 0; i < cornerIndices.size(); ++i) {
+            const int index = cornerIndices[i];
+            if (index < 0 || index >= numElements) {
+                return VtValue();
+            }
+            dst[i] = src[index];
+        }
+        return VtValue(result);
+    }
+
+    // Fallback for non-array values, which cannot be gathered.
+    VtValue operator()(const VtValue& value) const {
+        return VtValue();
+    }
+};
+
+VtValue
+_GatherElements(const VtValue& value, const VtIntArray& cornerIndices)
+{
+    return VtVisitValue(value, _GatherElementsVisitor{cornerIndices});
+}
+
+// Flattens a face-varying channel's index buffer (one entry per refined
+// patch) into one index per corner of the mesh's faceVertexIndices buffer.
+bool
+_FlattenFvarIndices(
+    const VtValue& indices,
+    size_t numCorners,
+    VtIntArray* flattened)
+{
+    if (indices.IsHolding<VtArray<GfVec3i>>()) {
+        // Triangle patches (loop scheme) map 1:1 onto the triangle list.
+        const VtArray<GfVec3i>& tris = indices.UncheckedGet<VtArray<GfVec3i>>();
+        if (tris.size() * 3 != numCorners) {
+            return false;
+        }
+        flattened->resize(numCorners);
+        int* dst = flattened->data();
+        for (const GfVec3i& tri : tris) {
+            *dst++ = tri[0];
+            *dst++ = tri[1];
+            *dst++ = tri[2];
+        }
+        return true;
+    }
+    if (indices.IsHolding<VtArray<GfVec4i>>()) {
+        // Quad patches (catmark/bilinear schemes). The mesh's index buffer
+        // was emitted by HdMeshTriQuadBuilder, which splits each quad into
+        // the triangles (0,1,2) and (2,3,0); apply the same split here so
+        // the corners line up.
+        const VtArray<GfVec4i>& quads = indices.UncheckedGet<VtArray<GfVec4i>>();
+        if (quads.size() * 6 != numCorners) {
+            return false;
+        }
+        flattened->resize(numCorners);
+        int* dst = flattened->data();
+        for (const GfVec4i& quad : quads) {
+            *dst++ = quad[0];
+            *dst++ = quad[1];
+            *dst++ = quad[2];
+            *dst++ = quad[2];
+            *dst++ = quad[3];
+            *dst++ = quad[0];
+        }
+        return true;
+    }
+    // Adaptive refinement (bspline/box spline patches) is not supported.
+    return false;
+}
+
+// Builds one coarse-face index per corner so uniform (per-face) primvars
+// can be expanded. primitiveParam has one entry per triangle for unrefined
+// meshes (int) and one entry per patch for refined meshes (GfVec3i with
+// the encoded param in element [0]). The number of corners per entry
+// (3 for triangles, 6 for triangulated quads) falls out of the buffer
+// sizes.
+bool
+_BuildUniformCornerIndices(
+    const VtValue& primitiveParam,
+    size_t numCorners,
+    VtIntArray* cornerIndices)
+{
+    VtIntArray encodedParams;
+    if (primitiveParam.IsHolding<VtIntArray>()) {
+        encodedParams = primitiveParam.UncheckedGet<VtIntArray>();
+    } else if (primitiveParam.IsHolding<VtArray<GfVec3i>>()) {
+        const VtArray<GfVec3i>& params =
+            primitiveParam.UncheckedGet<VtArray<GfVec3i>>();
+        encodedParams.resize(params.size());
+        for (size_t i = 0; i < params.size(); ++i) {
+            encodedParams[i] = params[i][0];
+        }
+    } else {
+        return false;
+    }
+
+    if (encodedParams.empty() || numCorners % encodedParams.size() != 0) {
+        return false;
+    }
+    const size_t cornersPerEntry = numCorners / encodedParams.size();
+    if (cornersPerEntry != 3 && cornersPerEntry != 6) {
+        return false;
+    }
+
+    cornerIndices->resize(numCorners);
+    int* dst = cornerIndices->data();
+    for (const int encodedParam : encodedParams) {
+        const int faceIndex =
+            HdMeshUtil::DecodeFaceIndexFromCoarseFaceParam(encodedParam);
+        for (size_t corner = 0; corner < cornersPerEntry; ++corner) {
+            *dst++ = faceIndex;
+        }
+    }
+    return true;
+}
+
+// Rewrites the mesh so that every non-constant primvar holds one value per
+// corner of faceVertexIndices, in corner order, and faceVertexIndices
+// becomes the identity. The result needs only a single (trivial) index
+// buffer, which is what renderers without multi-index support consume.
+void
+_DeindexMesh(HydraPassthroughRenderData::MeshData* meshData)
+{
+    // Keep a copy of the original vertex indices; they are overwritten at
+    // the end.
+    const VtIntArray vertexIndices = meshData->faceVertexIndices;
+    const size_t numCorners = vertexIndices.size();
+    if (numCorners == 0) {
+        return;
+    }
+
+    // Refined face-varying primvars hold compact value buffers that their
+    // channel's index buffer maps onto corners; expand them through those
+    // indices. Unrefined face-varying primvars have no channel and are
+    // already per-corner.
+    for (const HydraPassthroughRenderData::FaceVaryingChannel& channel :
+            meshData->faceVaryingChannels) {
+        VtIntArray cornerIndices;
+        if (!_FlattenFvarIndices(channel.indices, numCorners,
+                                 &cornerIndices)) {
+            TF_WARN("Face-varying channel %d of %s has indices that don't "
+                    "match the mesh's triangulated topology; leaving its "
+                    "primvars unexpanded",
+                    channel.channel, meshData->id.GetText());
+            continue;
+        }
+        for (const TfToken& name : channel.primvars) {
+            auto primvarIt = meshData->primvars.find(name);
+            if (primvarIt == meshData->primvars.end()) {
+                continue;
+            }
+            const VtValue expanded =
+                _GatherElements(primvarIt->second.data, cornerIndices);
+            if (expanded.IsEmpty()) {
+                TF_WARN("Could not expand face-varying primvar %s of %s",
+                        name.GetText(), meshData->id.GetText());
+                continue;
+            }
+            primvarIt->second.data = expanded;
+        }
+    }
+    meshData->faceVaryingChannels.clear();
+
+    // Built on demand if we encounter a uniform primvar.
+    VtIntArray uniformCornerIndices;
+    bool builtUniformCornerIndices = false;
+
+    for (auto& primvarEntry : meshData->primvars) {
+        const TfToken& name = primvarEntry.first;
+        HydraPassthroughRenderData::PrimvarData& primvar =
+            primvarEntry.second;
+
+        switch (primvar.interpolation) {
+            case HdInterpolationVertex:
+            case HdInterpolationVarying: {
+                const VtValue expanded =
+                    _GatherElements(primvar.data, vertexIndices);
+                if (expanded.IsEmpty()) {
+                    TF_WARN("Could not expand vertex/varying primvar %s of %s",
+                            name.GetText(), meshData->id.GetText());
+                    break;
+                }
+                primvar.data = expanded;
+                primvar.interpolation = HdInterpolationFaceVarying;
+                break;
+            }
+            case HdInterpolationUniform: {
+                if (!builtUniformCornerIndices) {
+                    builtUniformCornerIndices = true;
+                    if (!_BuildUniformCornerIndices(
+                            meshData->primitiveParam, numCorners,
+                            &uniformCornerIndices)) {
+                        TF_WARN("Could not map faces to corners for %s; "
+                                "leaving uniform primvars unexpanded",
+                                meshData->id.GetText());
+                    }
+                }
+                if (uniformCornerIndices.empty()) {
+                    break;
+                }
+                const VtValue expanded =
+                    _GatherElements(primvar.data, uniformCornerIndices);
+                if (expanded.IsEmpty()) {
+                    TF_WARN("Could not expand uniform primvar %s of %s",
+                            name.GetText(), meshData->id.GetText());
+                    break;
+                }
+                primvar.data = expanded;
+                primvar.interpolation = HdInterpolationFaceVarying;
+                break;
+            }
+            case HdInterpolationFaceVarying: {
+                // Already one value per corner; just sanity check.
+                if (primvar.data.GetArraySize() != numCorners) {
+                    TF_WARN("Face-varying primvar %s of %s has %zu values, "
+                            "expected %zu",
+                            name.GetText(), meshData->id.GetText(),
+                            primvar.data.GetArraySize(), numCorners);
+                }
+                break;
+            }
+            default:
+                // Constant and other interpolations are unaffected.
+                break;
+        }
+    }
+
+    // The points member mirrors the points primvar; keep them consistent.
+    if (!meshData->points.IsEmpty()) {
+        const VtValue expanded =
+            _GatherElements(meshData->points, vertexIndices);
+        if (!expanded.IsEmpty()) {
+            meshData->points = expanded;
+        }
+    }
+
+    // Every buffer is per-corner now, so the indices become the identity.
+    VtIntArray identity(numCorners);
+    std::iota(identity.begin(), identity.end(), 0);
+    meshData->faceVertexIndices = identity;
+}
+
+} // anonymous namespace
+
+HydraPassthroughRenderData::RenderData
+HydraPassthroughRenderData::ExtractDeindexedRenderDataCopy() const {
+    RenderData renderData = ExtractRenderDataCopy();
+    for (auto& meshEntry : renderData.meshes) {
+        _DeindexMesh(&meshEntry.second);
+    }
+    return renderData;
 }
 
 size_t

--- a/pxr/usdImaging/hydraPassthrough/renderData.cpp
+++ b/pxr/usdImaging/hydraPassthrough/renderData.cpp
@@ -390,6 +390,15 @@ HydraPassthroughRenderData::ExtractDeindexedRenderDataCopy() const {
     return renderData;
 }
 
+HydraPassthroughRenderData::RenderData
+HydraPassthroughRenderData::ExtractWeldedRenderDataCopy() const {
+    RenderData renderData = ExtractRenderDataCopy();
+    for (auto& meshEntry : renderData.meshes) {
+        PackagingUtil::WeldMesh(&meshEntry.second);
+    }
+    return renderData;
+}
+
 size_t
 HydraPassthroughRenderData::GetMeshCount() const
 {

--- a/pxr/usdImaging/hydraPassthrough/renderData.h
+++ b/pxr/usdImaging/hydraPassthrough/renderData.h
@@ -224,6 +224,22 @@ public:
     /// manager has performed its cleanup.
     RenderData ExtractRenderDataCopy() const;
 
+    /// Extract a copy of the contained RenderData with all mesh primvars
+    /// de-indexed into per-corner (face-varying) buffers.
+    ///
+    /// Renderers that support only a single index buffer per mesh (e.g.
+    /// three.js) cannot combine vertex-indexed positions with separately
+    /// indexed face-varying primvars like uvs. In this copy every
+    /// non-constant primvar of each mesh, along with the points, holds
+    /// one value per corner of faceVertexIndices, in corner order.
+    /// Expanded primvars report faceVarying interpolation, the
+    /// faceVaryingChannels are consumed (cleared), and faceVertexIndices
+    /// becomes the identity, so the geometry can be used non-indexed.
+    ///
+    /// For refined (subdivided) buffers this also drops the unused coarse
+    /// values that OpenSubdiv keeps at the start of each buffer.
+    RenderData ExtractDeindexedRenderDataCopy() const;
+
     // Duplicate some api from RenderData. This is for the contained
     // instance of render data, and is protected by the mutexes.
     size_t GetMeshCount() const;

--- a/pxr/usdImaging/hydraPassthrough/renderData.h
+++ b/pxr/usdImaging/hydraPassthrough/renderData.h
@@ -240,6 +240,21 @@ public:
     /// values that OpenSubdiv keeps at the start of each buffer.
     RenderData ExtractDeindexedRenderDataCopy() const;
 
+    /// Extract a copy of the contained RenderData with each mesh welded
+    /// into a single-index layout.
+    ///
+    /// This produces the same renderer-facing contract as
+    /// ExtractDeindexedRenderDataCopy — one shared index buffer, all
+    /// non-constant primvars parallel to points — but with the minimal
+    /// vertex count: corners share an output vertex unless one of their
+    /// attributes genuinely differs (a uv seam, a uniform value change),
+    /// so buffer sizes stay close to plain indexed geometry instead of
+    /// tripling. Face-varying data welds by channel indices where they
+    /// exist (refined meshes) and by exact bitwise value equality
+    /// otherwise; there is no epsilon. Expanded primvars report vertex
+    /// interpolation.
+    RenderData ExtractWeldedRenderDataCopy() const;
+
     // Duplicate some api from RenderData. This is for the contained
     // instance of render data, and is protected by the mutexes.
     size_t GetMeshCount() const;

--- a/pxr/usdImaging/hydraPassthrough/resourceRegistry.cpp
+++ b/pxr/usdImaging/hydraPassthrough/resourceRegistry.cpp
@@ -89,9 +89,11 @@ void HydraPassthroughResourceRegistry::AddIndexSources(
 void HydraPassthroughResourceRegistry::AddPrimvarSource(
         SdfPath const &id,
         HdBufferSourceSharedPtr const &source,
-        HdInterpolation interpolation)
+        HdInterpolation interpolation,
+        bool isIntermediate)
 {
-    _AddSource(source, id, PrimvarSourceType::Primvar, interpolation);
+    _AddSource(source, id, PrimvarSourceType::Primvar, interpolation,
+               isIntermediate);
 }
 
 void HydraPassthroughResourceRegistry::AddPrimvarSources(

--- a/pxr/usdImaging/hydraPassthrough/resourceRegistry.h
+++ b/pxr/usdImaging/hydraPassthrough/resourceRegistry.h
@@ -49,9 +49,16 @@ public:
                          HdBufferSourceSharedPtrVector &&sources);
 
     // Append a computation for a Primvar
+    //
+    // Sources marked intermediate are resolved (so computations that
+    // depend on them can run) but are not copied into the render data.
+    // Use this for coarse inputs that a triangulation/quadrangulation/
+    // refinement computation will replace with a final buffer of the
+    // same name.
     void AddPrimvarSource(SdfPath const &id,
                           HdBufferSourceSharedPtr const &source,
-                          HdInterpolation interpolation);
+                          HdInterpolation interpolation,
+                          bool isIntermediate = false);
 
     /// Append a list of primvar computations
     void AddPrimvarSources(SdfPath const &id,

--- a/pxr/usdImaging/hydraPassthrough/testenv/testHydraPassthroughMeshData.py
+++ b/pxr/usdImaging/hydraPassthrough/testenv/testHydraPassthroughMeshData.py
@@ -307,6 +307,96 @@ class TestMeshData(unittest.TestCase):
         self.assertEqual(list(st_welded.data.GetValue()),
                          [Gf.Vec2f(*vertex_uvs[i]) for i in range(6)])
 
+    def test_TriangleMeshFaceVarying(self):
+        # A mesh that is already all triangles: HdMeshUtil reports the
+        # face-varying triangulation as "Unchanged" and the source buffer
+        # must be passed through rather than dropped. This is the common
+        # case for usdz assets, which are typically pre-triangulated.
+        stage = Usd.Stage.CreateInMemory()
+        mesh_prim = UsdGeom.Mesh.Define(stage, '/Tris')
+        mesh_prim.CreateSubdivisionSchemeAttr(UsdGeom.Tokens.none)
+        points = [(0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0)]
+        mesh_prim.CreatePointsAttr(Vt.Vec3fArray(points))
+        mesh_prim.CreateFaceVertexCountsAttr(Vt.IntArray([3, 3]))
+        mesh_prim.CreateFaceVertexIndicesAttr(
+            Vt.IntArray([0, 1, 2, 0, 2, 3]))
+
+        # Indexed st, like typical pre-triangulated exports
+        compact_uvs = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)]
+        st_indices = [0, 1, 2, 0, 2, 3]
+        st_primvar = UsdGeom.PrimvarsAPI(mesh_prim).CreatePrimvar(
+            'st', Sdf.ValueTypeNames.TexCoord2fArray,
+            UsdGeom.Tokens.faceVarying)
+        st_primvar.Set(Vt.Vec2fArray(compact_uvs))
+        st_primvar.SetIndices(Vt.IntArray(st_indices))
+
+        m = HydraPassthrough.RenderManager()
+        m.Initialize()
+        try:
+            m.Render(stage)
+            data_copy = m.GetRenderData().ExtractRenderDataCopy()
+        finally:
+            m.Cleanup()
+
+        prefix = HydraPassthrough.RenderManager.GetSceneDelegateId()
+        mesh = data_copy.GetMesh(Sdf.Path(prefix.AppendPath('Tris')))
+        self.assertIsNotNone(mesh)
+
+        # The topology passes through untriangulated
+        self.assertEqual(list(mesh.GetFaceVertexIndices().GetValue()),
+                         [0, 1, 2, 0, 2, 3])
+
+        # st must be present: the flattened source is already per corner
+        st_out = mesh.GetPrimvar('st')
+        self.assertIsNotNone(st_out)
+        self.assertEqual(st_out.interpolation, UsdGeom.Tokens.faceVarying)
+        self.assertEqual(list(st_out.data.GetValue()),
+                         [Gf.Vec2f(*compact_uvs[i]) for i in st_indices])
+
+    def test_WeldedExtractionIndexedUvs(self):
+        # An indexed face-varying primvar on an unrefined mesh: the scene
+        # delegate hands the pipeline the flattened value, so authored
+        # indices are invisible downstream and welding behaves exactly as
+        # for a non-indexed primvar with the same effective values.
+        stage = Usd.Stage.CreateInMemory()
+        points, _ = create_two_quad_plane_usd(stage)
+
+        # Author st as a compact value array plus indices, continuous
+        # across the shared edge (corners of both faces reference the same
+        # elements there)
+        mesh_prim = UsdGeom.Mesh(stage.GetPrimAtPath('/Plane'))
+        compact_uvs = [(0.0, 0.0), (0.5, 0.0), (0.5, 1.0), (0.0, 1.0),
+                       (1.0, 0.0), (1.0, 1.0)]
+        st_primvar = UsdGeom.PrimvarsAPI(mesh_prim).GetPrimvar('st')
+        st_primvar.Set(Vt.Vec2fArray(compact_uvs))
+        st_primvar.SetIndices(Vt.IntArray([0, 1, 2, 3, 1, 4, 5, 2]))
+
+        # Drop the uniform primvar so nothing else forces splits
+        UsdGeom.PrimvarsAPI(mesh_prim).RemovePrimvar('myUniform')
+
+        m = HydraPassthrough.RenderManager()
+        m.Initialize()
+        try:
+            m.Render(stage)
+            data_copy = m.GetRenderData().ExtractWeldedRenderDataCopy()
+        finally:
+            m.Cleanup()
+
+        prefix = HydraPassthrough.RenderManager.GetSceneDelegateId()
+        mesh = data_copy.GetMesh(Sdf.Path(prefix.AppendPath('Plane')))
+        self.assertIsNotNone(mesh)
+
+        # The uvs are continuous, so welding recovers full vertex sharing
+        self.assertEqual(len(mesh.GetPoints().GetValue()), len(points))
+        self.assertEqual(list(mesh.GetFaceVertexIndices().GetValue()),
+                         [0, 1, 2, 0, 2, 3, 1, 4, 5, 1, 5, 2])
+
+        st_welded = mesh.GetPrimvar('st')
+        self.assertIsNotNone(st_welded)
+        self.assertEqual(st_welded.interpolation, UsdGeom.Tokens.vertex)
+        self.assertEqual(list(st_welded.data.GetValue()),
+                         [Gf.Vec2f(*compact_uvs[i]) for i in range(6)])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pxr/usdImaging/hydraPassthrough/testenv/testHydraPassthroughMeshData.py
+++ b/pxr/usdImaging/hydraPassthrough/testenv/testHydraPassthroughMeshData.py
@@ -1,7 +1,41 @@
 #!/pxrpythonsubst
 
-from pxr import Gf, HydraPassthrough, Sdf, Usd, UsdGeom
+from pxr import Gf, HydraPassthrough, Sdf, Usd, UsdGeom, Vt
 import unittest
+
+
+def create_two_quad_plane_usd(stage):
+    """Create an unsubdivided two-quad plane with a face-varying st primvar
+    that has a seam between the two faces, plus vertex and uniform primvars.
+    """
+    mesh = UsdGeom.Mesh.Define(stage, '/Plane')
+    mesh.CreateSubdivisionSchemeAttr(UsdGeom.Tokens.none)
+
+    points = [(0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0),
+              (2, 0, 0), (2, 1, 0)]
+    mesh.CreatePointsAttr(Vt.Vec3fArray(points))
+    mesh.CreateFaceVertexCountsAttr(Vt.IntArray([4, 4]))
+    mesh.CreateFaceVertexIndicesAttr(Vt.IntArray([0, 1, 2, 3, 1, 4, 5, 2]))
+
+    primvars = UsdGeom.PrimvarsAPI(mesh)
+
+    # Four st values per face, discontinuous across the shared edge
+    st = [(0.0, 0.0), (0.5, 0.0), (0.5, 1.0), (0.0, 1.0),
+          (0.6, 0.0), (1.0, 0.0), (1.0, 1.0), (0.6, 1.0)]
+    st_primvar = primvars.CreatePrimvar(
+        'st', Sdf.ValueTypeNames.TexCoord2fArray, UsdGeom.Tokens.faceVarying)
+    st_primvar.Set(Vt.Vec2fArray(st))
+
+    colors = [(i / 10.0, 0.0, 0.0) for i in range(len(points))]
+    color_primvar = primvars.CreatePrimvar(
+        'displayColor', Sdf.ValueTypeNames.Color3fArray, UsdGeom.Tokens.vertex)
+    color_primvar.Set(Vt.Vec3fArray(colors))
+
+    uniform_primvar = primvars.CreatePrimvar(
+        'myUniform', Sdf.ValueTypeNames.FloatArray, UsdGeom.Tokens.uniform)
+    uniform_primvar.Set(Vt.FloatArray([10.0, 20.0]))
+
+    return points, st
 
 
 class TestMeshData(unittest.TestCase):
@@ -83,6 +117,95 @@ class TestMeshData(unittest.TestCase):
         with self.assertRaises(Exception):
             self.assertEqual(md.GetMeshCount(), 1)
 
+    def test_UnrefinedFaceVarying(self):
+        # An unsubdivided mesh with a face-varying primvar: the primvar is
+        # triangulated into one value per corner and needs no face-varying
+        # channel.
+        stage = Usd.Stage.CreateInMemory()
+        points, st = create_two_quad_plane_usd(stage)
+
+        m = HydraPassthrough.RenderManager()
+        m.Initialize()
+        try:
+            m.Render(stage)
+            data_copy = m.GetRenderData().ExtractRenderDataCopy()
+        finally:
+            m.Cleanup()
+
+        prefix = HydraPassthrough.RenderManager.GetSceneDelegateId()
+        mesh = data_copy.GetMesh(Sdf.Path(prefix.AppendPath('Plane')))
+        self.assertIsNotNone(mesh)
+
+        # Each quad (a, b, c, d) is fan-triangulated into (a, b, c), (a, c, d)
+        expected_corner_verts = [0, 1, 2, 0, 2, 3, 1, 4, 5, 1, 5, 2]
+        expected_st_corners = [0, 1, 2, 0, 2, 3, 4, 5, 6, 4, 6, 7]
+
+        self.assertEqual(list(mesh.GetFaceVertexIndices().GetValue()),
+                         expected_corner_verts)
+
+        # Points are untouched by the plain copy
+        self.assertEqual(len(mesh.GetPoints().GetValue()), len(points))
+
+        # The st primvar is already triangulated per corner, with no channel
+        st_primvar = mesh.GetPrimvar('st')
+        self.assertEqual(st_primvar.interpolation, UsdGeom.Tokens.faceVarying)
+        self.assertEqual(list(st_primvar.data.GetValue()),
+                         [Gf.Vec2f(*st[i]) for i in expected_st_corners])
+        self.assertEqual(mesh.GetFaceVaryingChannels(), [])
+
+    def test_DeindexedExtraction(self):
+        # ExtractDeindexedRenderDataCopy expands every non-constant primvar
+        # to one value per corner, in corner order, with identity indices.
+        stage = Usd.Stage.CreateInMemory()
+        points, st = create_two_quad_plane_usd(stage)
+
+        m = HydraPassthrough.RenderManager()
+        m.Initialize()
+        try:
+            m.Render(stage)
+            data_copy = m.GetRenderData().ExtractDeindexedRenderDataCopy()
+        finally:
+            m.Cleanup()
+
+        prefix = HydraPassthrough.RenderManager.GetSceneDelegateId()
+        mesh = data_copy.GetMesh(Sdf.Path(prefix.AppendPath('Plane')))
+        self.assertIsNotNone(mesh)
+
+        expected_corner_verts = [0, 1, 2, 0, 2, 3, 1, 4, 5, 1, 5, 2]
+        expected_st_corners = [0, 1, 2, 0, 2, 3, 4, 5, 6, 4, 6, 7]
+        num_corners = len(expected_corner_verts)
+
+        # Indices become the identity
+        self.assertEqual(list(mesh.GetFaceVertexIndices().GetValue()),
+                         list(range(num_corners)))
+
+        # Points are expanded per corner
+        self.assertEqual(list(mesh.GetPoints().GetValue()),
+                         [Gf.Vec3f(*points[i]) for i in expected_corner_verts])
+
+        # Face-varying st is unchanged (already per corner)
+        st_primvar = mesh.GetPrimvar('st')
+        self.assertEqual(st_primvar.interpolation, UsdGeom.Tokens.faceVarying)
+        self.assertEqual(list(st_primvar.data.GetValue()),
+                         [Gf.Vec2f(*st[i]) for i in expected_st_corners])
+
+        # Vertex displayColor is expanded per corner and reports faceVarying
+        color_primvar = mesh.GetPrimvar('displayColor')
+        self.assertEqual(color_primvar.interpolation,
+                         UsdGeom.Tokens.faceVarying)
+        self.assertEqual(
+            list(color_primvar.data.GetValue()),
+            [Gf.Vec3f(i / 10.0, 0.0, 0.0) for i in expected_corner_verts])
+
+        # Uniform primvars are expanded per corner of each source face
+        uniform_primvar = mesh.GetPrimvar('myUniform')
+        self.assertEqual(uniform_primvar.interpolation,
+                         UsdGeom.Tokens.faceVarying)
+        self.assertEqual(list(uniform_primvar.data.GetValue()),
+                         [10.0] * 6 + [20.0] * 6)
+
+        # The channels are consumed by de-indexing
+        self.assertEqual(mesh.GetFaceVaryingChannels(), [])
 
 
 if __name__ == "__main__":

--- a/pxr/usdImaging/hydraPassthrough/testenv/testHydraPassthroughMeshData.py
+++ b/pxr/usdImaging/hydraPassthrough/testenv/testHydraPassthroughMeshData.py
@@ -207,6 +207,106 @@ class TestMeshData(unittest.TestCase):
         # The channels are consumed by de-indexing
         self.assertEqual(mesh.GetFaceVaryingChannels(), [])
 
+    def test_WeldedExtraction(self):
+        # ExtractWeldedRenderDataCopy produces the same single-index
+        # contract as de-indexing, but shares vertices wherever all
+        # attributes agree, splitting only across seams.
+        stage = Usd.Stage.CreateInMemory()
+        points, st = create_two_quad_plane_usd(stage)
+
+        m = HydraPassthrough.RenderManager()
+        m.Initialize()
+        try:
+            m.Render(stage)
+            data_copy = m.GetRenderData().ExtractWeldedRenderDataCopy()
+        finally:
+            m.Cleanup()
+
+        prefix = HydraPassthrough.RenderManager.GetSceneDelegateId()
+        mesh = data_copy.GetMesh(Sdf.Path(prefix.AppendPath('Plane')))
+        self.assertIsNotNone(mesh)
+
+        # 12 corners weld into 8 vertices: within each quad the two
+        # triangles share their diagonal corners, but the seam in st (and
+        # the uniform primvar) splits the two vertices shared between the
+        # quads. Output vertices are numbered in order of first use, so
+        # the welded index buffer is deterministic.
+        expected_indices = [0, 1, 2, 0, 2, 3, 4, 5, 6, 4, 6, 7]
+        # Source vertex and st element feeding each welded vertex
+        welded_verts = [0, 1, 2, 3, 1, 4, 5, 2]
+        welded_sts = [0, 1, 2, 3, 4, 5, 6, 7]
+
+        self.assertEqual(list(mesh.GetFaceVertexIndices().GetValue()),
+                         expected_indices)
+
+        self.assertEqual(list(mesh.GetPoints().GetValue()),
+                         [Gf.Vec3f(*points[i]) for i in welded_verts])
+
+        # All welded primvars are parallel to points and report vertex
+        # interpolation
+        st_primvar = mesh.GetPrimvar('st')
+        self.assertEqual(st_primvar.interpolation, UsdGeom.Tokens.vertex)
+        self.assertEqual(list(st_primvar.data.GetValue()),
+                         [Gf.Vec2f(*st[i]) for i in welded_sts])
+
+        color_primvar = mesh.GetPrimvar('displayColor')
+        self.assertEqual(color_primvar.interpolation, UsdGeom.Tokens.vertex)
+        self.assertEqual(
+            list(color_primvar.data.GetValue()),
+            [Gf.Vec3f(i / 10.0, 0.0, 0.0) for i in welded_verts])
+
+        uniform_primvar = mesh.GetPrimvar('myUniform')
+        self.assertEqual(uniform_primvar.interpolation,
+                         UsdGeom.Tokens.vertex)
+        self.assertEqual(list(uniform_primvar.data.GetValue()),
+                         [10.0] * 4 + [20.0] * 4)
+
+        # The channels are consumed by welding
+        self.assertEqual(mesh.GetFaceVaryingChannels(), [])
+
+    def test_WeldedExtractionContinuousUvs(self):
+        # When the face-varying data has no seams, welding recovers plain
+        # vertex sharing: no splits, uv array length matches points.
+        stage = Usd.Stage.CreateInMemory()
+        points, _ = create_two_quad_plane_usd(stage)
+
+        # Overwrite st with values that are continuous across the shared
+        # edge (one distinct value per vertex of each corner)
+        mesh_prim = UsdGeom.Mesh(stage.GetPrimAtPath('/Plane'))
+        vertex_indices = [0, 1, 2, 3, 1, 4, 5, 2]
+        vertex_uvs = [(0.0, 0.0), (0.4, 0.0), (0.4, 1.0), (0.0, 1.0),
+                      (1.0, 0.0), (1.0, 1.0)]
+        continuous_st = [vertex_uvs[i] for i in vertex_indices]
+        st_primvar = UsdGeom.PrimvarsAPI(mesh_prim).GetPrimvar('st')
+        st_primvar.Set(Vt.Vec2fArray(continuous_st))
+
+        # Drop the uniform primvar so nothing else forces splits
+        UsdGeom.PrimvarsAPI(mesh_prim).RemovePrimvar('myUniform')
+
+        m = HydraPassthrough.RenderManager()
+        m.Initialize()
+        try:
+            m.Render(stage)
+            data_copy = m.GetRenderData().ExtractWeldedRenderDataCopy()
+        finally:
+            m.Cleanup()
+
+        prefix = HydraPassthrough.RenderManager.GetSceneDelegateId()
+        mesh = data_copy.GetMesh(Sdf.Path(prefix.AppendPath('Plane')))
+        self.assertIsNotNone(mesh)
+
+        # Six vertices in, six vertices out: continuous uvs cost nothing.
+        # Welded vertices are numbered in order of first use by the
+        # triangulated corners [0,1,2, 0,2,3, 1,4,5, 1,5,2].
+        self.assertEqual(len(mesh.GetPoints().GetValue()), len(points))
+        self.assertEqual(list(mesh.GetFaceVertexIndices().GetValue()),
+                         [0, 1, 2, 0, 2, 3, 1, 4, 5, 1, 5, 2])
+
+        st_welded = mesh.GetPrimvar('st')
+        self.assertEqual(st_welded.interpolation, UsdGeom.Tokens.vertex)
+        self.assertEqual(list(st_welded.data.GetValue()),
+                         [Gf.Vec2f(*vertex_uvs[i]) for i in range(6)])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pxr/usdImaging/hydraPassthrough/triangulate.cpp
+++ b/pxr/usdImaging/hydraPassthrough/triangulate.cpp
@@ -105,17 +105,29 @@ HydraPassthroughTriangulateFaceVaryingComputation::Resolve()
 
     VtValue result;
     HdMeshUtil meshUtil(_topology, _id);
-    if(HdMeshComputationResult::Error !=
-            meshUtil.ComputeTriangulatedFaceVaryingPrimvar(
-                _source->GetData(),
-                _source->GetNumElements(),
-                _source->GetTupleType().type,
-                &result)) {
-        _SetResult(std::make_shared<HdVtBufferSource>(
-                        _source->GetName(),
-                        result));
-    } else {
-        _SetResult(_source);
+    const HdMeshComputationResult computationResult =
+        meshUtil.ComputeTriangulatedFaceVaryingPrimvar(
+            _source->GetData(),
+            _source->GetNumElements(),
+            _source->GetTupleType().type,
+            &result);
+    switch (computationResult) {
+        case HdMeshComputationResult::Success:
+            _SetResult(std::make_shared<HdVtBufferSource>(
+                            _source->GetName(),
+                            result));
+            break;
+        case HdMeshComputationResult::Unchanged:
+            // The topology is already all triangles, so the source is
+            // already one value per corner and `result` was left empty.
+            // Wrapping the empty result would produce a zero-length buffer
+            // that is discarded downstream; pass the source through
+            // instead, as HdSt_TriangulateFaceVaryingComputation does.
+            _SetResult(_source);
+            break;
+        case HdMeshComputationResult::Error:
+            _SetResult(_source);
+            break;
     }
 
     _SetResolved();

--- a/pxr/usdImaging/hydraPassthrough/wrapRenderData.cpp
+++ b/pxr/usdImaging/hydraPassthrough/wrapRenderData.cpp
@@ -225,6 +225,8 @@ wrapRenderData()
         .def("ExtractRenderDataCopy", &This::ExtractRenderDataCopy)
         .def("ExtractDeindexedRenderDataCopy",
              &This::ExtractDeindexedRenderDataCopy)
+        .def("ExtractWeldedRenderDataCopy",
+             &This::ExtractWeldedRenderDataCopy)
         ;
 
     class_<This::RenderData>("RenderDataStruct", no_init)

--- a/pxr/usdImaging/hydraPassthrough/wrapRenderData.cpp
+++ b/pxr/usdImaging/hydraPassthrough/wrapRenderData.cpp
@@ -223,6 +223,8 @@ wrapRenderData()
              return_internal_reference())
 
         .def("ExtractRenderDataCopy", &This::ExtractRenderDataCopy)
+        .def("ExtractDeindexedRenderDataCopy",
+             &This::ExtractDeindexedRenderDataCopy)
         ;
 
     class_<This::RenderData>("RenderDataStruct", no_init)


### PR DESCRIPTION
This fixes a common issue where assets are created with face varying uvs, even though vertex would be equivalent. We use more memory than is necessary in that case through this approach. Next I'll work on an approach to fuse vertices, which should give us the same fix with better memory characteristics.