### PR TITLE
First steps toward instancing support

### DIFF
--- a/pxr/usdImaging/hydraPassthrough/CMakeLists.txt
+++ b/pxr/usdImaging/hydraPassthrough/CMakeLists.txt
@@ -32,6 +32,7 @@ pxr_library(hydraPassthrough
         extCompPrimvarBufferSource
         fvarTopologyTracker
         hdTypeUtil
+        instancer
         material
         materialParam
         mesh
@@ -84,6 +85,7 @@ pxr_build_test(testHydraPassthroughValueDescriptor
 
 pxr_test_scripts(
     testenv/testHydraPassthroughCameraData.py
+    testenv/testHydraPassthroughInstancing.py
     testenv/testHydraPassthroughMeshData.py
     testenv/testHydraPassthroughMaterialData.py
     testenv/testHydraPassthroughSubdivision.py
@@ -114,5 +116,11 @@ pxr_register_test(testHydraPassthroughValueDescriptor
 pxr_register_test(testHydraPassthroughSubdivision
     PYTHON
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHydraPassthroughSubdivision"
+    EXPECTED_RETURN_CODE 0
+)
+
+pxr_register_test(testHydraPassthroughInstancing
+    PYTHON
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHydraPassthroughInstancing"
     EXPECTED_RETURN_CODE 0
 )

--- a/pxr/usdImaging/hydraPassthrough/instancer.cpp
+++ b/pxr/usdImaging/hydraPassthrough/instancer.cpp
@@ -1,0 +1,257 @@
+#include "instancer.h"
+
+#include "pxr/imaging/hd/changeTracker.h"
+#include "pxr/imaging/hd/renderIndex.h"
+#include "pxr/imaging/hd/sceneDelegate.h"
+#include "pxr/imaging/hd/tokens.h"
+
+#include "pxr/base/gf/matrix4d.h"
+#include "pxr/base/gf/matrix4f.h"
+#include "pxr/base/gf/quatd.h"
+#include "pxr/base/gf/quatf.h"
+#include "pxr/base/gf/quath.h"
+#include "pxr/base/gf/vec3d.h"
+#include "pxr/base/gf/vec3f.h"
+#include "pxr/base/gf/vec4d.h"
+#include "pxr/base/gf/vec4f.h"
+#include "pxr/base/tf/stl.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+namespace {
+
+// The scene index emulation hands us the instance primvars as VtValues
+// holding arrays. Which held type we see depends on the source: point
+// instancers author vec3f positions/scales and quath (or quatf)
+// orientations, while the native instance aggregation scene index produces
+// matrix4d transforms. These helpers sample one element as double
+// precision, returning false if the value holds an unexpected type or the
+// index is out of range. Callers treat a false return as identity.
+
+bool
+_SampleVec3(const VtValue &value, int index, GfVec3d *out)
+{
+    const size_t i = static_cast<size_t>(index);
+    if (value.IsHolding<VtVec3fArray>()) {
+        const VtVec3fArray &array = value.UncheckedGet<VtVec3fArray>();
+        if (i < array.size()) {
+            *out = GfVec3d(array[i]);
+            return true;
+        }
+    } else if (value.IsHolding<VtVec3dArray>()) {
+        const VtVec3dArray &array = value.UncheckedGet<VtVec3dArray>();
+        if (i < array.size()) {
+            *out = array[i];
+            return true;
+        }
+    }
+    return false;
+}
+
+bool
+_SampleQuat(const VtValue &value, int index, GfQuatd *out)
+{
+    const size_t i = static_cast<size_t>(index);
+    if (value.IsHolding<VtQuathArray>()) {
+        const VtQuathArray &array = value.UncheckedGet<VtQuathArray>();
+        if (i < array.size()) {
+            *out = GfQuatd(array[i]);
+            return true;
+        }
+    } else if (value.IsHolding<VtQuatfArray>()) {
+        const VtQuatfArray &array = value.UncheckedGet<VtQuatfArray>();
+        if (i < array.size()) {
+            *out = GfQuatd(array[i]);
+            return true;
+        }
+    } else if (value.IsHolding<VtQuatdArray>()) {
+        const VtQuatdArray &array = value.UncheckedGet<VtQuatdArray>();
+        if (i < array.size()) {
+            *out = array[i];
+            return true;
+        }
+    } else if (value.IsHolding<VtVec4fArray>()) {
+        // Quaternion packed as <real, i, j, k>
+        const VtVec4fArray &array = value.UncheckedGet<VtVec4fArray>();
+        if (i < array.size()) {
+            const GfVec4f &q = array[i];
+            *out = GfQuatd(q[0], q[1], q[2], q[3]);
+            return true;
+        }
+    } else if (value.IsHolding<VtVec4dArray>()) {
+        const VtVec4dArray &array = value.UncheckedGet<VtVec4dArray>();
+        if (i < array.size()) {
+            const GfVec4d &q = array[i];
+            *out = GfQuatd(q[0], q[1], q[2], q[3]);
+            return true;
+        }
+    }
+    return false;
+}
+
+bool
+_SampleMatrix(const VtValue &value, int index, GfMatrix4d *out)
+{
+    const size_t i = static_cast<size_t>(index);
+    if (value.IsHolding<VtMatrix4dArray>()) {
+        const VtMatrix4dArray &array = value.UncheckedGet<VtMatrix4dArray>();
+        if (i < array.size()) {
+            *out = array[i];
+            return true;
+        }
+    } else if (value.IsHolding<VtMatrix4fArray>()) {
+        const VtMatrix4fArray &array = value.UncheckedGet<VtMatrix4fArray>();
+        if (i < array.size()) {
+            *out = GfMatrix4d(array[i]);
+            return true;
+        }
+    }
+    return false;
+}
+
+} // anonymous namespace
+
+HydraPassthroughInstancer::HydraPassthroughInstancer(
+    HdSceneDelegate *delegate, SdfPath const &id)
+    : HdInstancer(delegate, id)
+{
+}
+
+HydraPassthroughInstancer::~HydraPassthroughInstancer() = default;
+
+void
+HydraPassthroughInstancer::Sync(HdSceneDelegate *sceneDelegate,
+                                HdRenderParam *renderParam,
+                                HdDirtyBits *dirtyBits)
+{
+    if (*dirtyBits & HdChangeTracker::DirtyVisibility) {
+        _visible = sceneDelegate->GetVisible(GetId());
+    }
+
+    _UpdateInstancer(sceneDelegate, dirtyBits);
+
+    if (HdChangeTracker::IsAnyPrimvarDirty(*dirtyBits, GetId())) {
+        _SyncPrimvars(sceneDelegate, *dirtyBits);
+    }
+}
+
+void
+HydraPassthroughInstancer::_SyncPrimvars(HdSceneDelegate *sceneDelegate,
+                                         HdDirtyBits dirtyBits)
+{
+    HD_TRACE_FUNCTION();
+    HF_MALLOC_TAG_FUNCTION();
+
+    SdfPath const &id = GetId();
+
+    HdPrimvarDescriptorVector primvars =
+        sceneDelegate->GetPrimvarDescriptors(id, HdInterpolationInstance);
+
+    for (const HdPrimvarDescriptor &pv : primvars) {
+        if (HdChangeTracker::IsPrimvarDirty(dirtyBits, id, pv.name)) {
+            VtValue value = sceneDelegate->Get(id, pv.name);
+            if (!value.IsEmpty()) {
+                _primvarMap[pv.name] = value;
+            }
+        }
+    }
+}
+
+VtMatrix4dArray
+HydraPassthroughInstancer::ComputeInstanceTransforms(
+    SdfPath const &prototypeId)
+{
+    HD_TRACE_FUNCTION();
+    HF_MALLOC_TAG_FUNCTION();
+
+    // The transforms for this level of instancer are computed by:
+    // foreach(index : indices) {
+    //     instancerTransform
+    //     * hydra:instanceTranslations(index)
+    //     * hydra:instanceRotations(index)
+    //     * hydra:instanceScales(index)
+    //     * hydra:instanceTransforms(index)
+    // }
+    // If any transform isn't provided, it's assumed to be the identity.
+
+    if (!_visible) {
+        return VtMatrix4dArray();
+    }
+
+    const GfMatrix4d instancerTransform =
+        GetDelegate()->GetInstancerTransform(GetId());
+    const VtIntArray instanceIndices =
+        GetDelegate()->GetInstanceIndices(GetId(), prototypeId);
+
+    const VtValue *translations =
+        TfMapLookupPtr(_primvarMap, HdInstancerTokens->instanceTranslations);
+    const VtValue *rotations =
+        TfMapLookupPtr(_primvarMap, HdInstancerTokens->instanceRotations);
+    const VtValue *scales =
+        TfMapLookupPtr(_primvarMap, HdInstancerTokens->instanceScales);
+    const VtValue *instanceTransforms =
+        TfMapLookupPtr(_primvarMap, HdInstancerTokens->instanceTransforms);
+
+    VtMatrix4dArray transforms(instanceIndices.size());
+    for (size_t i = 0; i < instanceIndices.size(); ++i) {
+        const int index = instanceIndices[i];
+        GfMatrix4d transform = instancerTransform;
+
+        GfVec3d translate;
+        if (translations && _SampleVec3(*translations, index, &translate)) {
+            GfMatrix4d translateMat(1);
+            translateMat.SetTranslate(translate);
+            transform = translateMat * transform;
+        }
+
+        GfQuatd rotate;
+        if (rotations && _SampleQuat(*rotations, index, &rotate)) {
+            GfMatrix4d rotateMat(1);
+            rotateMat.SetRotate(rotate);
+            transform = rotateMat * transform;
+        }
+
+        GfVec3d scale;
+        if (scales && _SampleVec3(*scales, index, &scale)) {
+            GfMatrix4d scaleMat(1);
+            scaleMat.SetScale(scale);
+            transform = scaleMat * transform;
+        }
+
+        GfMatrix4d instanceTransform;
+        if (instanceTransforms &&
+            _SampleMatrix(*instanceTransforms, index, &instanceTransform)) {
+            transform = instanceTransform * transform;
+        }
+
+        transforms[i] = transform;
+    }
+
+    if (GetParentId().IsEmpty()) {
+        return transforms;
+    }
+
+    // Nested instancing: this whole instancer is itself instanced by its
+    // parent, so multiply every local transform by every parent transform,
+    // flattening outer-major.
+    HdInstancer *parentInstancer =
+        GetDelegate()->GetRenderIndex().GetInstancer(GetParentId());
+    if (!TF_VERIFY(parentInstancer)) {
+        return transforms;
+    }
+
+    const VtMatrix4dArray parentTransforms =
+        static_cast<HydraPassthroughInstancer*>(parentInstancer)->
+            ComputeInstanceTransforms(GetId());
+
+    VtMatrix4dArray final(parentTransforms.size() * transforms.size());
+    for (size_t i = 0; i < parentTransforms.size(); ++i) {
+        for (size_t j = 0; j < transforms.size(); ++j) {
+            final[i * transforms.size() + j] =
+                transforms[j] * parentTransforms[i];
+        }
+    }
+    return final;
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usdImaging/hydraPassthrough/instancer.cpp
+++ b/pxr/usdImaging/hydraPassthrough/instancer.cpp
@@ -147,10 +147,32 @@ HydraPassthroughInstancer::_SyncPrimvars(HdSceneDelegate *sceneDelegate,
     HdPrimvarDescriptorVector primvars =
         sceneDelegate->GetPrimvarDescriptors(id, HdInterpolationInstance);
 
+    // Drop cached values for primvars that no longer exist. A removal
+    // arrives as a primvar-dirty notification, and the removed name simply
+    // stops being listed in the descriptors.
+    TfTokenVector removedNames;
+    for (const auto &entry : _primvarMap) {
+        bool stillExists = false;
+        for (const HdPrimvarDescriptor &pv : primvars) {
+            if (pv.name == entry.first) {
+                stillExists = true;
+                break;
+            }
+        }
+        if (!stillExists) {
+            removedNames.push_back(entry.first);
+        }
+    }
+    for (const TfToken &name : removedNames) {
+        _primvarMap.erase(name);
+    }
+
     for (const HdPrimvarDescriptor &pv : primvars) {
         if (HdChangeTracker::IsPrimvarDirty(dirtyBits, id, pv.name)) {
             VtValue value = sceneDelegate->Get(id, pv.name);
-            if (!value.IsEmpty()) {
+            if (value.IsEmpty()) {
+                _primvarMap.erase(pv.name);
+            } else {
                 _primvarMap[pv.name] = value;
             }
         }

--- a/pxr/usdImaging/hydraPassthrough/instancer.cpp
+++ b/pxr/usdImaging/hydraPassthrough/instancer.cpp
@@ -1,8 +1,14 @@
 #include "instancer.h"
 
+#include "renderData.h"
+
 #include "pxr/imaging/hd/changeTracker.h"
+#include "pxr/imaging/hd/instanceSchema.h"
+#include "pxr/imaging/hd/instancerTopologySchema.h"
 #include "pxr/imaging/hd/renderIndex.h"
 #include "pxr/imaging/hd/sceneDelegate.h"
+#include "pxr/imaging/hd/sceneIndex.h"
+#include "pxr/imaging/hd/sceneIndexPrimView.h"
 #include "pxr/imaging/hd/tokens.h"
 
 #include "pxr/base/gf/matrix4d.h"
@@ -15,8 +21,6 @@
 #include "pxr/base/gf/vec4d.h"
 #include "pxr/base/gf/vec4f.h"
 #include "pxr/base/tf/stl.h"
-// The gather/expand visitors below instantiate over every VtArray element
-// type, which requires the complete type of each element.
 #include "pxr/base/vt/typeHeaders.h"
 #include "pxr/base/vt/visitValue.h"
 
@@ -401,6 +405,92 @@ HydraPassthroughInstancer::ComputeInstanceData(
     }
 
     result = std::move(flattened);
+}
+
+/* static */
+void
+HydraPassthroughInstancer::PopulateInstancerOrigins(
+    HdSceneIndexBaseRefPtr const &sceneIndex,
+    HydraPassthroughRenderDataRefPtr const &renderData,
+    SdfPath const &sceneDelegateId)
+{
+    if (!sceneIndex || !renderData) {
+        return;
+    }
+
+    // When native instances are aggregated into an instancer, the
+    // aggregation scene index leaves an "instance" data source at each
+    // original instance prim's location, pointing at the instancer that
+    // absorbed it. Collect those into a per-instancer map from instance
+    // index to origin prim path.
+    //
+    // We traverse our scene index rather than the render index's view of
+    // it, so the origin paths come out unprefixed, matching the source
+    // scene. The instancer ids get the scene delegate prefix added so they
+    // match the instancerId the prototype meshes report.
+    TfHashMap<SdfPath, HydraPassthroughRenderData::SceneGraphInstancerData, TfHash>
+        instancers;
+
+    for (const SdfPath &primPath : HdSceneIndexPrimView(sceneIndex)) {
+        const HdSceneIndexPrim prim = sceneIndex->GetPrim(primPath);
+        const HdInstanceSchema instanceSchema =
+            HdInstanceSchema::GetFromParent(prim.dataSource);
+        if (!instanceSchema.IsDefined()) {
+            continue;
+        }
+
+        HdPathDataSourceHandle const instancerDs =
+            instanceSchema.GetInstancer();
+        HdIntDataSourceHandle const instanceIndexDs =
+            instanceSchema.GetInstanceIndex();
+        if (!instancerDs || !instanceIndexDs) {
+            continue;
+        }
+
+        const SdfPath instancerPath = instancerDs->GetTypedValue(0.0f);
+        const int slot = instanceIndexDs->GetTypedValue(0.0f);
+        if (instancerPath.IsEmpty() || slot < 0) {
+            continue;
+        }
+        int prototypeIndex = 0;
+        if (HdIntDataSourceHandle const prototypeIndexDs =
+                instanceSchema.GetPrototypeIndex()) {
+            prototypeIndex = prototypeIndexDs->GetTypedValue(0.0f);
+        }
+
+        // The schema's instanceIndex is a position within the instancer
+        // topology's per-prototype index array. Resolve it to the instance
+        // index value there, which is what the prototype meshes report in
+        // their instanceIndices. (For instancers created by native instance
+        // aggregation these are the same today, but the schema doesn't
+        // promise that.)
+        int instanceIndex = slot;
+        const HdSceneIndexPrim instancerPrim =
+            sceneIndex->GetPrim(instancerPath);
+        if (const HdInstancerTopologySchema topologySchema =
+                HdInstancerTopologySchema::GetFromParent(
+                    instancerPrim.dataSource)) {
+            if (HdIntArrayDataSourceHandle const indicesDs =
+                    topologySchema.GetInstanceIndices().GetElement(
+                        prototypeIndex)) {
+                const VtIntArray indices = indicesDs->GetTypedValue(0.0f);
+                if (static_cast<size_t>(slot) < indices.size()) {
+                    instanceIndex = indices[slot];
+                }
+            }
+        }
+
+        const SdfPath prefixedInstancerId = instancerPath.ReplacePrefix(
+            SdfPath::AbsoluteRootPath(), sceneDelegateId);
+        HydraPassthroughRenderData::SceneGraphInstancerData &instancerData =
+            instancers[prefixedInstancerId];
+        instancerData.id = prefixedInstancerId;
+        instancerData.instanceOriginPaths[instanceIndex] = primPath;
+    }
+
+    for (const auto &entry : instancers) {
+        renderData->AddSceneGraphInstancer(entry.first, entry.second);
+    }
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usdImaging/hydraPassthrough/instancer.cpp
+++ b/pxr/usdImaging/hydraPassthrough/instancer.cpp
@@ -246,14 +246,24 @@ HydraPassthroughInstancer::_SyncPrimvars(HdSceneDelegate *sceneDelegate,
     }
 }
 
-HydraPassthroughInstancer::InstanceData
+void
 HydraPassthroughInstancer::ComputeInstanceData(
-    SdfPath const &prototypeId)
+    SdfPath const &prototypeId,
+    InstanceData *instanceData)
 {
     HD_TRACE_FUNCTION();
     HF_MALLOC_TAG_FUNCTION();
 
-    InstanceData result;
+    if (!TF_VERIFY(instanceData)) {
+        return;
+    }
+
+    // Start from empty output, which is also the result for an invisible
+    // instancer.
+    InstanceData &result = *instanceData;
+    result.transforms.clear();
+    result.instanceIndices.clear();
+    result.primvars.clear();
 
     // The transforms for this level of instancer are computed by:
     // foreach(index : indices) {
@@ -266,7 +276,7 @@ HydraPassthroughInstancer::ComputeInstanceData(
     // If any transform isn't provided, it's assumed to be the identity.
 
     if (!_visible) {
-        return result;
+        return;
     }
 
     const GfMatrix4d instancerTransform =
@@ -335,7 +345,7 @@ HydraPassthroughInstancer::ComputeInstanceData(
     }
 
     if (GetParentId().IsEmpty()) {
-        return result;
+        return;
     }
 
     // Nested instancing: this whole instancer is itself instanced by its
@@ -344,12 +354,12 @@ HydraPassthroughInstancer::ComputeInstanceData(
     HdInstancer *parentInstancer =
         GetDelegate()->GetRenderIndex().GetInstancer(GetParentId());
     if (!TF_VERIFY(parentInstancer)) {
-        return result;
+        return;
     }
 
-    const InstanceData parent =
-        static_cast<HydraPassthroughInstancer*>(parentInstancer)->
-            ComputeInstanceData(GetId());
+    InstanceData parent;
+    static_cast<HydraPassthroughInstancer*>(parentInstancer)->
+        ComputeInstanceData(GetId(), &parent);
 
     const size_t numLocal = result.transforms.size();
     const size_t numParent = parent.transforms.size();
@@ -390,7 +400,7 @@ HydraPassthroughInstancer::ComputeInstanceData(
         }
     }
 
-    return flattened;
+    result = std::move(flattened);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usdImaging/hydraPassthrough/instancer.cpp
+++ b/pxr/usdImaging/hydraPassthrough/instancer.cpp
@@ -15,6 +15,12 @@
 #include "pxr/base/gf/vec4d.h"
 #include "pxr/base/gf/vec4f.h"
 #include "pxr/base/tf/stl.h"
+// The gather/expand visitors below instantiate over every VtArray element
+// type, which requires the complete type of each element.
+#include "pxr/base/vt/typeHeaders.h"
+#include "pxr/base/vt/visitValue.h"
+
+#include <algorithm>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -109,6 +115,67 @@ _SampleMatrix(const VtValue &value, int index, GfMatrix4d *out)
     return false;
 }
 
+// Gathers elements of an array-holding VtValue by index:
+// out[k] = in[indices[k]]. Out-of-range indices produce default-constructed
+// elements. Returns an empty VtValue for non-array values.
+struct _GatherVisitor {
+    const VtIntArray &indices;
+
+    template <class T>
+    VtValue operator()(const VtArray<T> &array) const {
+        VtArray<T> result(indices.size());
+        for (size_t i = 0; i < indices.size(); ++i) {
+            const size_t index = static_cast<size_t>(indices[i]);
+            if (index < array.size()) {
+                result[i] = array[index];
+            }
+        }
+        return VtValue(result);
+    }
+
+    VtValue operator()(const VtValue &value) const {
+        return VtValue();
+    }
+};
+
+// Expands an array-holding VtValue for nested-instancing flattening: each
+// element is repeated repeatEach times consecutively, then the whole result
+// is tiled `tile` times:
+// out[t * (n * repeatEach) + i * repeatEach + r] = in[i]
+struct _ExpandVisitor {
+    size_t repeatEach;
+    size_t tile;
+
+    template <class T>
+    VtValue operator()(const VtArray<T> &array) const {
+        VtArray<T> result(array.size() * repeatEach * tile);
+        size_t k = 0;
+        for (size_t t = 0; t < tile; ++t) {
+            for (size_t i = 0; i < array.size(); ++i) {
+                for (size_t r = 0; r < repeatEach; ++r) {
+                    result[k++] = array[i];
+                }
+            }
+        }
+        return VtValue(result);
+    }
+
+    VtValue operator()(const VtValue &value) const {
+        return VtValue();
+    }
+};
+
+// The primvars that ComputeInstanceData bakes into the instance transforms,
+// and therefore excludes from the passed-through instance primvars.
+bool
+_IsTransformPrimvar(const TfToken &name)
+{
+    return name == HdInstancerTokens->instanceTranslations ||
+           name == HdInstancerTokens->instanceRotations ||
+           name == HdInstancerTokens->instanceScales ||
+           name == HdInstancerTokens->instanceTransforms;
+}
+
 } // anonymous namespace
 
 HydraPassthroughInstancer::HydraPassthroughInstancer(
@@ -179,12 +246,14 @@ HydraPassthroughInstancer::_SyncPrimvars(HdSceneDelegate *sceneDelegate,
     }
 }
 
-VtMatrix4dArray
-HydraPassthroughInstancer::ComputeInstanceTransforms(
+HydraPassthroughInstancer::InstanceData
+HydraPassthroughInstancer::ComputeInstanceData(
     SdfPath const &prototypeId)
 {
     HD_TRACE_FUNCTION();
     HF_MALLOC_TAG_FUNCTION();
+
+    InstanceData result;
 
     // The transforms for this level of instancer are computed by:
     // foreach(index : indices) {
@@ -197,7 +266,7 @@ HydraPassthroughInstancer::ComputeInstanceTransforms(
     // If any transform isn't provided, it's assumed to be the identity.
 
     if (!_visible) {
-        return VtMatrix4dArray();
+        return result;
     }
 
     const GfMatrix4d instancerTransform =
@@ -249,31 +318,79 @@ HydraPassthroughInstancer::ComputeInstanceTransforms(
         transforms[i] = transform;
     }
 
+    result.transforms = std::move(transforms);
+    result.instanceIndices = instanceIndices;
+
+    // Gather the non-transform instance primvars by instance index so each
+    // is parallel to the transforms.
+    for (const auto &entry : _primvarMap) {
+        if (_IsTransformPrimvar(entry.first)) {
+            continue;
+        }
+        VtValue gathered =
+            VtVisitValue(entry.second, _GatherVisitor{instanceIndices});
+        if (!gathered.IsEmpty()) {
+            result.primvars[entry.first] = std::move(gathered);
+        }
+    }
+
     if (GetParentId().IsEmpty()) {
-        return transforms;
+        return result;
     }
 
     // Nested instancing: this whole instancer is itself instanced by its
-    // parent, so multiply every local transform by every parent transform,
+    // parent, so combine every local instance with every parent instance,
     // flattening outer-major.
     HdInstancer *parentInstancer =
         GetDelegate()->GetRenderIndex().GetInstancer(GetParentId());
     if (!TF_VERIFY(parentInstancer)) {
-        return transforms;
+        return result;
     }
 
-    const VtMatrix4dArray parentTransforms =
+    const InstanceData parent =
         static_cast<HydraPassthroughInstancer*>(parentInstancer)->
-            ComputeInstanceTransforms(GetId());
+            ComputeInstanceData(GetId());
 
-    VtMatrix4dArray final(parentTransforms.size() * transforms.size());
-    for (size_t i = 0; i < parentTransforms.size(); ++i) {
-        for (size_t j = 0; j < transforms.size(); ++j) {
-            final[i * transforms.size() + j] =
-                transforms[j] * parentTransforms[i];
+    const size_t numLocal = result.transforms.size();
+    const size_t numParent = parent.transforms.size();
+
+    InstanceData flattened;
+
+    flattened.transforms = VtMatrix4dArray(numParent * numLocal);
+    flattened.instanceIndices = VtIntArray(numParent * numLocal);
+    for (size_t i = 0; i < numParent; ++i) {
+        for (size_t j = 0; j < numLocal; ++j) {
+            flattened.transforms[i * numLocal + j] =
+                result.transforms[j] * parent.transforms[i];
+            // Instance indices identify the level closest to the prototype,
+            // so the local indices just repeat for each parent instance.
+            flattened.instanceIndices[i * numLocal + j] =
+                result.instanceIndices[j];
         }
     }
-    return final;
+
+    // Local primvar values repeat for each parent instance; parent primvar
+    // values expand so each covers that parent's block of local instances.
+    // On a name collision the local (closest to the prototype) value wins.
+    for (const auto &entry : result.primvars) {
+        VtValue expanded = VtVisitValue(
+            entry.second, _ExpandVisitor{1 /* repeatEach */, numParent});
+        if (!expanded.IsEmpty()) {
+            flattened.primvars[entry.first] = std::move(expanded);
+        }
+    }
+    for (const auto &entry : parent.primvars) {
+        if (flattened.primvars.count(entry.first) > 0) {
+            continue;
+        }
+        VtValue expanded = VtVisitValue(
+            entry.second, _ExpandVisitor{numLocal, 1 /* tile */});
+        if (!expanded.IsEmpty()) {
+            flattened.primvars[entry.first] = std::move(expanded);
+        }
+    }
+
+    return flattened;
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usdImaging/hydraPassthrough/instancer.h
+++ b/pxr/usdImaging/hydraPassthrough/instancer.h
@@ -5,6 +5,7 @@
 
 #include "pxr/imaging/hd/instancer.h"
 
+#include "pxr/base/tf/declarePtrs.h"
 #include "pxr/base/tf/hashmap.h"
 #include "pxr/base/tf/token.h"
 #include "pxr/base/vt/array.h"
@@ -12,6 +13,9 @@
 #include "pxr/base/vt/value.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
+
+TF_DECLARE_REF_PTRS(HydraPassthroughRenderData);
+TF_DECLARE_REF_PTRS(HdSceneIndexBase);
 
 /// \class HydraPassthroughInstancer
 ///
@@ -73,6 +77,18 @@ public:
     /// Produces empty data if the instancer is invisible.
     void ComputeInstanceData(SdfPath const &prototypeId,
                              InstanceData *instanceData);
+
+    /// Collects the origin scene prim of every native (scene graph) instance
+    /// from the scene index into the render data, for pick mapping.
+    ///
+    /// Should be called after the render, when the scene index is fully
+    /// populated.
+    ///
+    /// Output is placed directly into the renderData.
+    static void PopulateInstancerOrigins(
+        HdSceneIndexBaseRefPtr const &sceneIndex,
+        HydraPassthroughRenderDataRefPtr const &renderData,
+        SdfPath const &sceneDelegateId);
 
 private:
     void _SyncPrimvars(HdSceneDelegate *sceneDelegate, HdDirtyBits dirtyBits);

--- a/pxr/usdImaging/hydraPassthrough/instancer.h
+++ b/pxr/usdImaging/hydraPassthrough/instancer.h
@@ -64,14 +64,15 @@ public:
     };
 
     /// Compute the flattened instance data for each instance of prototypeId
-    /// drawn by this instancer.
+    /// drawn by this instancer, replacing the contents of instanceData.
     ///
     /// Nested instancing is flattened here by recursing into the parent
     /// instancer. The result is ordered outer-major: all instances for the
     /// first parent instance, then all instances for the second, and so on.
     ///
-    /// Returns empty data if the instancer is invisible.
-    InstanceData ComputeInstanceData(SdfPath const &prototypeId);
+    /// Produces empty data if the instancer is invisible.
+    void ComputeInstanceData(SdfPath const &prototypeId,
+                             InstanceData *instanceData);
 
 private:
     void _SyncPrimvars(HdSceneDelegate *sceneDelegate, HdDirtyBits dirtyBits);

--- a/pxr/usdImaging/hydraPassthrough/instancer.h
+++ b/pxr/usdImaging/hydraPassthrough/instancer.h
@@ -7,6 +7,7 @@
 
 #include "pxr/base/tf/hashmap.h"
 #include "pxr/base/tf/token.h"
+#include "pxr/base/vt/array.h"
 #include "pxr/base/vt/types.h"
 #include "pxr/base/vt/value.h"
 
@@ -23,10 +24,10 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// hydra:instanceTransforms for aggregated native instances), with the
 /// prototype meshes pointing back at the instancer via their instancerId.
 ///
-/// Sync() caches the instance primvars. ComputeInstanceTransforms() is then
+/// Sync() caches the instance primvars. ComputeInstanceData() is then
 /// called by prototype rprims during their own Sync to compose the cached
-/// primvars into one matrix per instance, recursing into the parent
-/// instancer when instancers are nested.
+/// primvars into per-instance transforms, indices and primvar values,
+/// recursing into the parent instancer when instancers are nested.
 ///
 class HydraPassthroughInstancer final : public HdInstancer {
 public:
@@ -38,18 +39,39 @@ public:
               HdRenderParam *renderParam,
               HdDirtyBits *dirtyBits) override;
 
-    /// Compute the transform for each instance of prototypeId drawn by this
-    /// instancer, following the composition rules described in
-    /// pxr/imaging/hd/instancer.h. Each returned matrix takes the prototype
-    /// from instancer space to world space; it does not include the
-    /// prototype rprim's own transform.
+    /// The flattened per-instance data for one prototype. The three members
+    /// are parallel: entry k of each describes the same drawn instance.
+    struct InstanceData {
+        /// One transform per instance, following the composition rules
+        /// described in pxr/imaging/hd/instancer.h. Each matrix takes the
+        /// prototype from instancer space to world space; it does not
+        /// include the prototype rprim's own transform.
+        VtMatrix4dArray transforms;
+
+        /// For each instance, the instance index at the instancer level
+        /// closest to the prototype. For point instancers these are indices
+        /// into the authored point arrays (masked instances are omitted,
+        /// not renumbered).
+        VtIntArray instanceIndices;
+
+        /// Non-transform instance-interpolation primvars, gathered by
+        /// instance index into arrays parallel to transforms. The
+        /// transform-building primvars (hydra:instanceTranslations/
+        /// Rotations/Scales/Transforms) are excluded since they are baked
+        /// into the transforms. When nested instancers author the same
+        /// primvar, the level closest to the prototype wins.
+        TfHashMap<TfToken, VtValue, TfToken::HashFunctor> primvars;
+    };
+
+    /// Compute the flattened instance data for each instance of prototypeId
+    /// drawn by this instancer.
     ///
     /// Nested instancing is flattened here by recursing into the parent
     /// instancer. The result is ordered outer-major: all instances for the
     /// first parent instance, then all instances for the second, and so on.
     ///
-    /// Returns an empty array if the instancer is invisible.
-    VtMatrix4dArray ComputeInstanceTransforms(SdfPath const &prototypeId);
+    /// Returns empty data if the instancer is invisible.
+    InstanceData ComputeInstanceData(SdfPath const &prototypeId);
 
 private:
     void _SyncPrimvars(HdSceneDelegate *sceneDelegate, HdDirtyBits dirtyBits);

--- a/pxr/usdImaging/hydraPassthrough/instancer.h
+++ b/pxr/usdImaging/hydraPassthrough/instancer.h
@@ -1,0 +1,72 @@
+#ifndef USD_IMAGING_HYDRA_PASSTHROUGH_INSTANCER_H
+#define USD_IMAGING_HYDRA_PASSTHROUGH_INSTANCER_H
+
+#include "pxr/pxr.h"
+
+#include "pxr/imaging/hd/instancer.h"
+
+#include "pxr/base/tf/hashmap.h"
+#include "pxr/base/tf/token.h"
+#include "pxr/base/vt/types.h"
+#include "pxr/base/vt/value.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+/// \class HydraPassthroughInstancer
+///
+/// Computes flattened per-instance transforms for prototype rprims.
+///
+/// Both USD instancing styles arrive here in the same form: the usdImaging
+/// scene indices convert point instancers and native (instanceable) prims
+/// into hydra instancer prims carrying instance-interpolation primvars
+/// (hydra:instanceTranslations/Rotations/Scales for point instancers,
+/// hydra:instanceTransforms for aggregated native instances), with the
+/// prototype meshes pointing back at the instancer via their instancerId.
+///
+/// Sync() caches the instance primvars. ComputeInstanceTransforms() is then
+/// called by prototype rprims during their own Sync to compose the cached
+/// primvars into one matrix per instance, recursing into the parent
+/// instancer when instancers are nested.
+///
+class HydraPassthroughInstancer final : public HdInstancer {
+public:
+    HydraPassthroughInstancer(HdSceneDelegate *delegate, SdfPath const &id);
+
+    ~HydraPassthroughInstancer() override;
+
+    void Sync(HdSceneDelegate *sceneDelegate,
+              HdRenderParam *renderParam,
+              HdDirtyBits *dirtyBits) override;
+
+    /// Compute the transform for each instance of prototypeId drawn by this
+    /// instancer, following the composition rules described in
+    /// pxr/imaging/hd/instancer.h. Each returned matrix takes the prototype
+    /// from instancer space to world space; it does not include the
+    /// prototype rprim's own transform.
+    ///
+    /// Nested instancing is flattened here by recursing into the parent
+    /// instancer. The result is ordered outer-major: all instances for the
+    /// first parent instance, then all instances for the second, and so on.
+    ///
+    /// Returns an empty array if the instancer is invisible.
+    VtMatrix4dArray ComputeInstanceTransforms(SdfPath const &prototypeId);
+
+private:
+    void _SyncPrimvars(HdSceneDelegate *sceneDelegate, HdDirtyBits dirtyBits);
+
+    bool _visible{true};
+
+    // Cached instance-interpolation primvar values, keyed by primvar name.
+    // Written by Sync, which hydra serializes per instancer, and read
+    // concurrently afterwards by the prototype rprims' parallel Sync calls.
+    TfHashMap<TfToken, VtValue, TfToken::HashFunctor> _primvarMap;
+
+    // This class does not support copying.
+    HydraPassthroughInstancer(const HydraPassthroughInstancer &) = delete;
+    HydraPassthroughInstancer &operator=(
+        const HydraPassthroughInstancer &) = delete;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // USD_IMAGING_HYDRA_PASSTHROUGH_INSTANCER_H

--- a/pxr/usdImaging/hydraPassthrough/mesh.cpp
+++ b/pxr/usdImaging/hydraPassthrough/mesh.cpp
@@ -159,8 +159,12 @@ HydraPassthroughMesh::_PopulateMeshValues(HdSceneDelegate* sceneDelegate,
     _meshData.fvarTopologyTracker = &_fvarTopologyTracker;
 
     // Update our cached instancer binding, then make sure the instancer and
-    // any parent instancers have synced before we read from them. Hydra
-    // serializes the instancer syncs behind a lock; rprims sync in parallel.
+    // any parent instancers have synced before we read from them. Rprims
+    // sync in parallel, so many meshes can request the same instancer's
+    // sync concurrently; _SyncInstancerAndParents serializes those requests
+    // with a mutex internal to HdInstancer and only the caller that finds
+    // dirty bits does the work. Once it returns the instancer's data is
+    // stable until the next frame, so reading it below needs no lock.
     _UpdateInstancer(sceneDelegate, dirtyBits);
     HdInstancer::_SyncInstancerAndParents(
         sceneDelegate->GetRenderIndex(), GetInstancerId());

--- a/pxr/usdImaging/hydraPassthrough/mesh.cpp
+++ b/pxr/usdImaging/hydraPassthrough/mesh.cpp
@@ -1,4 +1,5 @@
 #include "mesh.h"
+#include "instancer.h"
 #include "meshUtil.h"
 #include "primUtil.h"
 #include "renderParam.h"
@@ -37,7 +38,7 @@ HdDirtyBits HydraPassthroughMesh::GetInitialDirtyBitsMask() const {
         | HdChangeTracker::DirtyPrimvar
         | HdChangeTracker::DirtyNormals
         | HdChangeTracker::DirtyMaterialId
-//        | HdChangeTracker::DirtyInstancer // no instancer support yet
+        | HdChangeTracker::DirtyInstancer
         ;
 
 }
@@ -156,6 +157,30 @@ HydraPassthroughMesh::_PopulateMeshValues(HdSceneDelegate* sceneDelegate,
     SdfPath const& id = GetId();
     _meshData.id = id;
     _meshData.fvarTopologyTracker = &_fvarTopologyTracker;
+
+    // Update our cached instancer binding, then make sure the instancer and
+    // any parent instancers have synced before we read from them. Hydra
+    // serializes the instancer syncs behind a lock; rprims sync in parallel.
+    _UpdateInstancer(sceneDelegate, dirtyBits);
+    HdInstancer::_SyncInstancerAndParents(
+        sceneDelegate->GetRenderIndex(), GetInstancerId());
+
+    _meshData.instancerId = GetInstancerId();
+
+    if (HdChangeTracker::IsInstancerDirty(*dirtyBits, id) ||
+        HdChangeTracker::IsInstanceIndexDirty(*dirtyBits, id)) {
+        if (GetInstancerId().IsEmpty()) {
+            _meshData.instanceTransforms = VtMatrix4dArray();
+        } else {
+            HdInstancer *instancer =
+                sceneDelegate->GetRenderIndex().GetInstancer(GetInstancerId());
+            if (TF_VERIFY(instancer)) {
+                _meshData.instanceTransforms =
+                    static_cast<HydraPassthroughInstancer*>(instancer)->
+                        ComputeInstanceTransforms(GetId());
+            }
+        }
+    }
 
     if (*dirtyBits & HdChangeTracker::DirtyMaterialId) {
         _meshData.materialId = sceneDelegate->GetMaterialId(id);

--- a/pxr/usdImaging/hydraPassthrough/mesh.cpp
+++ b/pxr/usdImaging/hydraPassthrough/mesh.cpp
@@ -181,9 +181,9 @@ HydraPassthroughMesh::_PopulateMeshValues(HdSceneDelegate* sceneDelegate,
             HdInstancer *instancer =
                 sceneDelegate->GetRenderIndex().GetInstancer(GetInstancerId());
             if (TF_VERIFY(instancer)) {
-                HydraPassthroughInstancer::InstanceData instanceData =
-                    static_cast<HydraPassthroughInstancer*>(instancer)->
-                        ComputeInstanceData(GetId());
+                HydraPassthroughInstancer::InstanceData instanceData;
+                static_cast<HydraPassthroughInstancer*>(instancer)->
+                    ComputeInstanceData(GetId(), &instanceData);
                 _meshData.instanceTransforms =
                     std::move(instanceData.transforms);
                 _meshData.instanceIndices =

--- a/pxr/usdImaging/hydraPassthrough/mesh.cpp
+++ b/pxr/usdImaging/hydraPassthrough/mesh.cpp
@@ -175,13 +175,25 @@ HydraPassthroughMesh::_PopulateMeshValues(HdSceneDelegate* sceneDelegate,
         HdChangeTracker::IsInstanceIndexDirty(*dirtyBits, id)) {
         if (GetInstancerId().IsEmpty()) {
             _meshData.instanceTransforms = VtMatrix4dArray();
+            _meshData.instanceIndices = VtIntArray();
+            _meshData.instancePrimvars.clear();
         } else {
             HdInstancer *instancer =
                 sceneDelegate->GetRenderIndex().GetInstancer(GetInstancerId());
             if (TF_VERIFY(instancer)) {
-                _meshData.instanceTransforms =
+                HydraPassthroughInstancer::InstanceData instanceData =
                     static_cast<HydraPassthroughInstancer*>(instancer)->
-                        ComputeInstanceTransforms(GetId());
+                        ComputeInstanceData(GetId());
+                _meshData.instanceTransforms =
+                    std::move(instanceData.transforms);
+                _meshData.instanceIndices =
+                    std::move(instanceData.instanceIndices);
+                _meshData.instancePrimvars.clear();
+                for (const auto &pv : instanceData.primvars) {
+                    _meshData.instancePrimvars[pv.first] =
+                        HydraPassthroughRenderData::PrimvarData(
+                            pv.second, HdInterpolationInstance);
+                }
             }
         }
     }

--- a/pxr/usdImaging/hydraPassthrough/primUtil.cpp
+++ b/pxr/usdImaging/hydraPassthrough/primUtil.cpp
@@ -49,7 +49,6 @@ PopulateConstantPrimvars(
     HF_MALLOC_TAG_FUNCTION();
 
     SdfPath const& id = prim->GetId();
-    SdfPath const& instancerId = prim->GetInstancerId();
 
     HdBufferSourceSharedPtrVector sources;
 
@@ -77,42 +76,10 @@ PopulateConstantPrimvars(
                 HdTokens->transformInverse, VtValue(transform.GetInverse()),
                 doublesSupported));
 
+        // Note that instancer transforms are not handled here. They are
+        // folded into the per-instance transforms computed by
+        // HydraPassthroughInstancer::ComputeInstanceTransforms.
         bool leftHanded = transform.IsLeftHanded();
-
-        // If this is a prototype (has instancer),
-        // also push the instancer transform separately.
-        if (!instancerId.IsEmpty()) {
-            // Gather all instancer transforms in the instancing hierarchy
-            const VtMatrix4dArray rootTransforms = 
-                prim->GetInstancerTransforms(delegate);
-            VtMatrix4dArray rootInverseTransforms(rootTransforms.size());
-            for (size_t i = 0; i < rootTransforms.size(); ++i) {
-                rootInverseTransforms[i] = rootTransforms[i].GetInverse();
-                // Flip the handedness if necessary
-                leftHanded ^= rootTransforms[i].IsLeftHanded();
-            }
-
-            sources.push_back(
-                std::make_shared<HdVtBufferSource>(
-                    HdInstancerTokens->instancerTransform,
-                    rootTransforms,
-                    rootTransforms.size(),
-                    doublesSupported));
-            sources.push_back(
-                std::make_shared<HdVtBufferSource>(
-                    HdInstancerTokens->instancerTransformInverse,
-                    rootInverseTransforms,
-                    rootInverseTransforms.size(),
-                    doublesSupported));
-
-            // This seems to just be for shader optimization purposes,
-            // we might not need it, but would need to verify that in
-            // downstream computations.
-            sources.push_back(
-                std::make_shared<HdVtBufferSource>(
-                    HdTokens->isFlipped,
-                    VtValue(int(leftHanded))));
-        }
 
         if (hasMirroredTransform) {
             *hasMirroredTransform = leftHanded;

--- a/pxr/usdImaging/hydraPassthrough/primUtil.cpp
+++ b/pxr/usdImaging/hydraPassthrough/primUtil.cpp
@@ -78,7 +78,7 @@ PopulateConstantPrimvars(
 
         // Note that instancer transforms are not handled here. They are
         // folded into the per-instance transforms computed by
-        // HydraPassthroughInstancer::ComputeInstanceTransforms.
+        // HydraPassthroughInstancer::ComputeInstanceData.
         bool leftHanded = transform.IsLeftHanded();
 
         if (hasMirroredTransform) {

--- a/pxr/usdImaging/hydraPassthrough/renderData.cpp
+++ b/pxr/usdImaging/hydraPassthrough/renderData.cpp
@@ -88,7 +88,7 @@ HydraPassthroughRenderData::RenderData::GetMaterialCount() const {
     return materials.size();
 }
 
-const HydraPassthroughRenderData::MaterialData* 
+const HydraPassthroughRenderData::MaterialData*
 HydraPassthroughRenderData::RenderData::GetMaterialByIndex(size_t index) const {
     if (index >= materials.size()) {
         TF_RUNTIME_ERROR("Material index %zu out of range [0,%zu)",
@@ -97,6 +97,33 @@ HydraPassthroughRenderData::RenderData::GetMaterialByIndex(size_t index) const {
     }
 
     auto it = materials.begin();
+    std::advance(it, index);
+    return &(it->second);
+}
+
+const HydraPassthroughRenderData::SceneGraphInstancerData*
+HydraPassthroughRenderData::RenderData::GetSceneGraphInstancer(const SdfPath& id) const {
+    auto it = sceneGraphInstancers.find(id);
+    if (it != sceneGraphInstancers.end()) {
+        return &(it->second);
+    }
+    return nullptr;
+}
+
+size_t
+HydraPassthroughRenderData::RenderData::GetSceneGraphInstancerCount() const {
+    return sceneGraphInstancers.size();
+}
+
+const HydraPassthroughRenderData::SceneGraphInstancerData*
+HydraPassthroughRenderData::RenderData::GetSceneGraphInstancerByIndex(size_t index) const {
+    if (index >= sceneGraphInstancers.size()) {
+        TF_RUNTIME_ERROR("Instancer index %zu out of range [0,%zu)",
+            index, sceneGraphInstancers.size());
+        return nullptr;
+    }
+
+    auto it = sceneGraphInstancers.begin();
     std::advance(it, index);
     return &(it->second);
 }
@@ -180,13 +207,22 @@ HydraPassthroughRenderData::AddCamera(const HdCamera* camera) {
 }
 
 void
-HydraPassthroughRenderData::AddMaterial(const SdfPath& id, 
+HydraPassthroughRenderData::AddMaterial(const SdfPath& id,
                                         const MaterialData& matData) {
     const std::lock_guard<std::mutex> lock(_materialMutex);
     _renderData.materials[id] = matData;
 }
 
-static void _UpdateFaceVaryingChannels(HydraPassthroughRenderData::MeshData& meshData, const TfToken& primvarName) {
+void
+HydraPassthroughRenderData::AddSceneGraphInstancer(
+                            const SdfPath& id,
+                            const SceneGraphInstancerData& instancerData) {
+    const std::lock_guard<std::mutex> lock(_instancerMutex);
+    _renderData.sceneGraphInstancers[id] = instancerData;
+}
+
+static void _UpdateFaceVaryingChannels(HydraPassthroughRenderData::MeshData& meshData,
+                                       const TfToken& primvarName) {
     // If this is a face varying primvar, we need to add it to the appropriate
     // channel in faceVaryingChannels
 
@@ -378,6 +414,7 @@ HydraPassthroughRenderData::ExtractRenderDataCopy() const {
     const std::lock_guard<std::mutex> lock1(_meshMutex);
     const std::lock_guard<std::mutex> lock2(_cameraMutex);
     const std::lock_guard<std::mutex> lock3(_materialMutex);
+    const std::lock_guard<std::mutex> lock4(_instancerMutex);
     return _renderData;
 }
 
@@ -460,6 +497,27 @@ HydraPassthroughRenderData::GetMaterialByIndex(size_t index) const
 {
     const std::lock_guard<std::mutex> lock(_materialMutex);
     return _renderData.GetMaterialByIndex(index);
+}
+
+const HydraPassthroughRenderData::SceneGraphInstancerData*
+HydraPassthroughRenderData::GetSceneGraphInstancer(const SdfPath& id) const
+{
+    const std::lock_guard<std::mutex> lock(_instancerMutex);
+    return _renderData.GetSceneGraphInstancer(id);
+}
+
+size_t
+HydraPassthroughRenderData::GetSceneGraphInstancerCount() const
+{
+    const std::lock_guard<std::mutex> lock(_instancerMutex);
+    return _renderData.GetSceneGraphInstancerCount();
+}
+
+const HydraPassthroughRenderData::SceneGraphInstancerData*
+HydraPassthroughRenderData::GetSceneGraphInstancerByIndex(size_t index) const
+{
+    const std::lock_guard<std::mutex> lock(_instancerMutex);
+    return _renderData.GetSceneGraphInstancerByIndex(index);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usdImaging/hydraPassthrough/renderData.h
+++ b/pxr/usdImaging/hydraPassthrough/renderData.h
@@ -23,6 +23,7 @@
 #include "pxr/base/vt/dictionary.h"
 #include "pxr/base/vt/value.h"
 
+#include <map>
 #include <mutex>
 #include <string>
 
@@ -145,6 +146,32 @@ public:
         HydraPassthroughFvarTopologyTracker *fvarTopologyTracker;
     };
 
+    /// Data describing a scene graph instancer
+    ///
+    /// This exists to map drawn instances of native (scene graph) instancing
+    /// back to the scene prims that authored them, primarily for picking in
+    /// debug renders. Point instancers do not appear here; for those,
+    /// MeshData::instanceIndices already identifies the authored point on the
+    /// point instancer prim (the mesh's instancerId).
+    ///
+    /// Clients should check to see if a picked mesh has a
+    /// SceneGraphInstancerData object, and if so, use this to map to the
+    /// picked source prim.
+    class SceneGraphInstancerData {
+    public:
+        SdfPath id;
+
+        // For each instance index (the values reported in the prototype
+        // meshes' instanceIndices), the stage path of the original
+        // instanceable prim that was aggregated into that instance. So for
+        // drawn instance k of a prototype mesh m:
+        //
+        //   instanceOriginPaths.at(m.instanceIndices[k])
+        //
+        // is the scene prim that instance came from.
+        std::map<int, SdfPath> instanceOriginPaths;
+    };
+
     class MaterialData {
     public:
         SdfPath id;
@@ -220,6 +247,7 @@ public:
         TfHashMap<SdfPath, MeshData, TfHash> meshes;
         TfHashMap<SdfPath, CameraData, TfHash> cameras;
         TfHashMap<SdfPath, MaterialData, TfHash> materials;
+        TfHashMap<SdfPath, SceneGraphInstancerData, TfHash> sceneGraphInstancers;
 
         const MeshData* GetMesh(const SdfPath& id) const;
         size_t GetMeshCount() const;
@@ -230,6 +258,9 @@ public:
         const MaterialData* GetMaterial(const SdfPath& id) const;
         size_t GetMaterialCount() const;
         const MaterialData* GetMaterialByIndex(size_t index) const;
+        const SceneGraphInstancerData* GetSceneGraphInstancer(const SdfPath& id) const;
+        size_t GetSceneGraphInstancerCount() const;
+        const SceneGraphInstancerData* GetSceneGraphInstancerByIndex(size_t index) const;
     };
 
     static HydraPassthroughRenderDataRefPtr New() {
@@ -245,6 +276,9 @@ public:
 
     void AddMaterial(const SdfPath& id,
                      const MaterialData& materialData);
+
+    void AddSceneGraphInstancer(const SdfPath& id,
+                                const SceneGraphInstancerData& instancerData);
 
     /// Copy a potentially computed primvar source value into the render data.
     void CopyPrimvarBufferSource(
@@ -303,6 +337,9 @@ public:
     const MaterialData* GetMaterial(const SdfPath& id) const;
     size_t GetMaterialCount() const;
     const MaterialData* GetMaterialByIndex(size_t index) const;
+    const SceneGraphInstancerData* GetSceneGraphInstancer(const SdfPath& id) const;
+    size_t GetSceneGraphInstancerCount() const;
+    const SceneGraphInstancerData* GetSceneGraphInstancerByIndex(size_t index) const;
     // End duplicate api
 
 private:
@@ -315,6 +352,7 @@ private:
     mutable std::mutex _meshMutex;
     mutable std::mutex _cameraMutex;
     mutable std::mutex _materialMutex;
+    mutable std::mutex _instancerMutex;
 
     // The actual contained data.
     RenderData _renderData;

--- a/pxr/usdImaging/hydraPassthrough/renderData.h
+++ b/pxr/usdImaging/hydraPassthrough/renderData.h
@@ -19,6 +19,7 @@
 #include "pxr/base/tf/declarePtrs.h"
 #include "pxr/base/tf/hashmap.h"
 #include "pxr/base/vt/array.h"
+#include "pxr/base/vt/types.h"
 #include "pxr/base/vt/dictionary.h"
 #include "pxr/base/vt/value.h"
 
@@ -94,6 +95,24 @@ public:
         bool visible{true};
         GfMatrix4d transform;
         GfMatrix4d transformInverse;
+
+        // Instancing. If instancerId is non-empty this mesh is an instancing
+        // prototype and should be drawn once per entry in instanceTransforms.
+        // The full local-to-world for instance i is, in Gf's row-vector
+        // convention:
+        //
+        //   world = transform * instanceTransforms[i]
+        //
+        // i.e. the mesh's own transform applies first, then the instance
+        // transform. Column-vector clients (e.g. threejs) use the transposed
+        // matrices multiplied in the reverse order.
+        //
+        // An instanced mesh whose instances are all hidden (or masked out)
+        // has a non-empty instancerId and an empty instanceTransforms, and
+        // should not be drawn. Nested instancing arrives here already
+        // flattened, ordered outer-major.
+        SdfPath instancerId;
+        VtMatrix4dArray instanceTransforms;
         VtValue points;
         VtValue normals;
         VtIntArray faceVertexIndices; // triangles only

--- a/pxr/usdImaging/hydraPassthrough/renderData.h
+++ b/pxr/usdImaging/hydraPassthrough/renderData.h
@@ -95,6 +95,13 @@ public:
         bool visible{true};
         GfMatrix4d transform;
         GfMatrix4d transformInverse;
+        VtValue points;
+        VtValue normals;
+        VtIntArray faceVertexIndices; // triangles only
+        VtValue primitiveParam;
+        VtValue edgeIndices;
+        TfHashMap<TfToken, PrimvarData, TfToken::HashFunctor> primvars;
+        std::vector<FaceVaryingChannel> faceVaryingChannels;
 
         // Instancing. If instancerId is non-empty this mesh is an instancing
         // prototype and should be drawn once per entry in instanceTransforms.
@@ -113,13 +120,6 @@ public:
         // flattened, ordered outer-major.
         SdfPath instancerId;
         VtMatrix4dArray instanceTransforms;
-        VtValue points;
-        VtValue normals;
-        VtIntArray faceVertexIndices; // triangles only
-        VtValue primitiveParam;
-        VtValue edgeIndices;
-        TfHashMap<TfToken, PrimvarData, TfToken::HashFunctor> primvars;
-        std::vector<FaceVaryingChannel> faceVaryingChannels;
 
         // Not wrapped to python, valid only so long as the rprim mesh exists
         //

--- a/pxr/usdImaging/hydraPassthrough/renderData.h
+++ b/pxr/usdImaging/hydraPassthrough/renderData.h
@@ -121,6 +121,24 @@ public:
         SdfPath instancerId;
         VtMatrix4dArray instanceTransforms;
 
+        // For each entry in instanceTransforms, the instance index at the
+        // instancer level closest to the prototype. For a point instancer
+        // prototype this is the index into the authored point arrays
+        // (masked/invisible instances are omitted without renumbering), so
+        // a drawn instance can be mapped back to a specific point for
+        // picking or debugging. With nested instancers only the innermost
+        // level is identified.
+        VtIntArray instanceIndices;
+
+        // Instance-interpolation primvars (e.g. a displayColor authored on
+        // a point instancer), with values gathered per drawn instance so
+        // each array is parallel to instanceTransforms. The
+        // transform-building primvars (hydra:instanceTranslations/
+        // Rotations/Scales/Transforms) are excluded because they are
+        // already baked into instanceTransforms. When nested instancers
+        // author the same primvar, the level closest to the prototype wins.
+        TfHashMap<TfToken, PrimvarData, TfToken::HashFunctor> instancePrimvars;
+
         // Not wrapped to python, valid only so long as the rprim mesh exists
         //
         // We need this only to populate the face varying primvar index channels

--- a/pxr/usdImaging/hydraPassthrough/renderDelegate.cpp
+++ b/pxr/usdImaging/hydraPassthrough/renderDelegate.cpp
@@ -1,4 +1,5 @@
 #include "renderDelegate.h"
+#include "instancer.h"
 #include "material.h"
 #include "mesh.h"
 #include "renderPass.h"
@@ -157,12 +158,11 @@ void HydraPassthroughRenderDelegate::DestroyBprim(HdBprim *bPrim) {
 
 HdInstancer *HydraPassthroughRenderDelegate::CreateInstancer(HdSceneDelegate *delegate,
         SdfPath const &id) {
-    TF_CODING_ERROR("Creating Instancer not supported id=%s", id.GetText());
-    return nullptr;
+    return new HydraPassthroughInstancer(delegate, id);
 }
 
 void HydraPassthroughRenderDelegate::DestroyInstancer(HdInstancer *instancer) {
-    TF_CODING_ERROR("Destroy instancer not supported");
+    delete instancer;
 }
 
 HdRenderParam *HydraPassthroughRenderDelegate::GetRenderParam() const

--- a/pxr/usdImaging/hydraPassthrough/renderManager.cpp
+++ b/pxr/usdImaging/hydraPassthrough/renderManager.cpp
@@ -1,5 +1,7 @@
 #include "renderManager.h"
 
+#include "instancer.h"
+
 #include "pxr/usdImaging/hydraPassthrough/renderDelegate.h"
 #include "pxr/usdImaging/usdImaging/stageSceneIndex.h"
 
@@ -113,6 +115,11 @@ void HdPassthroughRenderManager::Render(const UsdStageRefPtr& stage) {
 
     // Render the frame using the engine
     _engine->Execute(_renderIndex.get(), _taskControllerSceneIndex->GetRenderingTaskPaths());
+
+    // Native instance origins are not visible to the render delegate (they
+    // are not rprims), so gather them from the scene index here.
+    HydraPassthroughInstancer::PopulateInstancerOrigins(
+            _sceneIndex, GetRenderData(), _sceneDelegateId);
 }
 
 void HdPassthroughRenderManager::Cleanup()

--- a/pxr/usdImaging/hydraPassthrough/testenv/testHydraPassthroughInstancing.py
+++ b/pxr/usdImaging/hydraPassthrough/testenv/testHydraPassthroughInstancing.py
@@ -172,6 +172,11 @@ class TestInstancing(unittest.TestCase):
         self.assertEqual(list(color_out.data.GetValue()),
                          [Gf.Vec3f(*colors[0]), Gf.Vec3f(*colors[2])])
 
+        # Point instancers have no aggregated instance origins; their
+        # pick mapping is the instance indices themselves
+        self.assertEqual(data.GetSceneGraphInstancerCount(), 0)
+        self.assertIsNone(data.GetSceneGraphInstancer(mesh.instancerId))
+
     def test_InstancePrimvars(self):
         # Primvars authored on a point instancer (other than the transform
         # builders) pass through as instance primvars, gathered per drawn
@@ -251,6 +256,23 @@ class TestInstancing(unittest.TestCase):
         # instance primvars (their transforms are the only instance data)
         self.assertEqual(sorted(mesh.GetInstanceIndices().GetValue()), [0, 1])
         self.assertEqual(mesh.GetAllInstancePrimvars(), [])
+
+        # Each drawn instance maps back to the instanceable prim that
+        # authored it: instancer origins are keyed by the values in
+        # instanceIndices, and the mapped prim's authored offset must match
+        # the drawn transform.
+        self.assertEqual(data.GetSceneGraphInstancerCount(), 1)
+        instancer = data.GetSceneGraphInstancer(mesh.instancerId)
+        self.assertIsNotNone(instancer)
+        origins = instancer.GetInstanceOriginPaths()
+        self.assertEqual(sorted(str(p) for p in origins.values()),
+                         ['/Instance0', '/Instance1'])
+        indices = list(mesh.GetInstanceIndices().GetValue())
+        for k, xform in enumerate(xforms):
+            origin = origins[indices[k]]
+            authored = offsets[int(str(origin).replace('/Instance', ''))]
+            got = tuple(round(c, 3) for c in xform.ExtractTranslation())
+            self.assertEqual(got, authored)
 
     def test_NestedPointInstancers(self):
         # A point instancer whose prototype contains another point

--- a/pxr/usdImaging/hydraPassthrough/testenv/testHydraPassthroughInstancing.py
+++ b/pxr/usdImaging/hydraPassthrough/testenv/testHydraPassthroughInstancing.py
@@ -1,0 +1,219 @@
+#!/pxrpythonsubst
+
+from pxr import Gf, HydraPassthrough, Sdf, Usd, UsdGeom, Vt
+import unittest
+
+
+def render_extract(stage):
+    """Render the stage and return an extracted RenderData copy."""
+    m = HydraPassthrough.RenderManager()
+    m.Initialize()
+    try:
+        m.Render(stage)
+        return m.GetRenderData().ExtractRenderDataCopy()
+    finally:
+        m.Cleanup()
+
+
+def get_meshes(data):
+    return [data.GetMeshByIndex(i) for i in range(data.GetMeshCount())]
+
+
+def create_quad(stage, path):
+    """A single unsubdivided quad to use as an instancing prototype."""
+    mesh = UsdGeom.Mesh.Define(stage, path)
+    mesh.CreateSubdivisionSchemeAttr(UsdGeom.Tokens.none)
+    mesh.CreatePointsAttr(
+        Vt.Vec3fArray([(0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0)]))
+    mesh.CreateFaceVertexCountsAttr(Vt.IntArray([4]))
+    mesh.CreateFaceVertexIndicesAttr(Vt.IntArray([0, 1, 2, 3]))
+    return mesh
+
+
+def translations(xforms, ndigits=3):
+    """Sorted, rounded translation tuples for order-insensitive compares."""
+    return sorted(
+        tuple(round(c, ndigits) for c in x.ExtractTranslation())
+        for x in xforms)
+
+
+class TestInstancing(unittest.TestCase):
+
+    def assertMatrixClose(self, a, b, eps=1e-4):
+        for row in range(4):
+            ra = a.GetRow(row)
+            rb = b.GetRow(row)
+            for col in range(4):
+                self.assertAlmostEqual(
+                    ra[col], rb[col], delta=eps,
+                    msg='mismatch at [%d][%d]:\n%s\nvs\n%s' % (
+                        row, col, a, b))
+
+    def test_NonInstancedMesh(self):
+        # A plain mesh reports no instancer and no instance transforms
+        stage = Usd.Stage.CreateInMemory()
+        create_quad(stage, '/Quad')
+
+        data = render_extract(stage)
+        meshes = get_meshes(data)
+        self.assertEqual(len(meshes), 1)
+        self.assertTrue(meshes[0].instancerId.isEmpty)
+        self.assertFalse(meshes[0].GetInstanceTransforms().GetValue())
+
+    def test_PointInstancer(self):
+        # A point instancer with positions, orientations and scales, and a
+        # transform on the instancer itself. The exported transforms must
+        # match what UsdGeomPointInstancer computes, composed with the
+        # instancer's own local-to-world.
+        stage = Usd.Stage.CreateInMemory()
+        pi = UsdGeom.PointInstancer.Define(stage, '/PI')
+        pi.AddTranslateOp().Set(Gf.Vec3d(10, 0, 0))
+        create_quad(stage, '/PI/Protos/Quad')
+        pi.CreatePrototypesRel().SetTargets([Sdf.Path('/PI/Protos/Quad')])
+        pi.CreateProtoIndicesAttr(Vt.IntArray([0, 0, 0]))
+        pi.CreatePositionsAttr(
+            Vt.Vec3fArray([(0, 0, 0), (5, 0, 0), (0, 5, 0)]))
+        pi.CreateScalesAttr(
+            Vt.Vec3fArray([(1, 1, 1), (2, 2, 2), (1, 3, 1)]))
+        # 90 degrees about Z for the middle instance
+        pi.CreateOrientationsAttr(Vt.QuathArray([
+            Gf.Quath(1),
+            Gf.Quath(0.7071, 0, 0, 0.7071),
+            Gf.Quath(1)]))
+
+        # Expected: the usd-computed per-instance transforms (in instancer
+        # space) times the instancer's local-to-world. Computed before
+        # rendering because RenderManager.Cleanup currently expires the
+        # caller's stage handles.
+        instancer_l2w = UsdGeom.XformCache().GetLocalToWorldTransform(
+            pi.GetPrim())
+        expected = pi.ComputeInstanceTransformsAtTime(
+            Usd.TimeCode.Default(), Usd.TimeCode.Default(),
+            UsdGeom.PointInstancer.ExcludeProtoXform)
+        self.assertEqual(len(expected), 3)
+
+        data = render_extract(stage)
+        meshes = get_meshes(data)
+        self.assertEqual(len(meshes), 1)
+        mesh = meshes[0]
+
+        self.assertFalse(mesh.instancerId.isEmpty)
+        xforms = mesh.GetInstanceTransforms().GetValue()
+        self.assertEqual(len(xforms), 3)
+
+        # A single-prototype instancer preserves point order
+        for got, want in zip(xforms, expected):
+            self.assertMatrixClose(got, want * instancer_l2w)
+
+    def test_PointInstancerMultiplePrototypes(self):
+        # Two prototypes sharing one instancer: each propagated mesh gets
+        # the transforms for its own protoIndices entries.
+        stage = Usd.Stage.CreateInMemory()
+        pi = UsdGeom.PointInstancer.Define(stage, '/PI')
+        create_quad(stage, '/PI/Protos/QuadA')
+        create_quad(stage, '/PI/Protos/QuadB')
+        pi.CreatePrototypesRel().SetTargets(
+            [Sdf.Path('/PI/Protos/QuadA'), Sdf.Path('/PI/Protos/QuadB')])
+        pi.CreateProtoIndicesAttr(Vt.IntArray([0, 1, 0]))
+        pi.CreatePositionsAttr(
+            Vt.Vec3fArray([(0, 0, 0), (5, 0, 0), (0, 5, 0)]))
+
+        data = render_extract(stage)
+        meshes = get_meshes(data)
+        self.assertEqual(len(meshes), 2)
+
+        counts = {}
+        for mesh in meshes:
+            self.assertFalse(mesh.instancerId.isEmpty)
+            xforms = mesh.GetInstanceTransforms().GetValue()
+            counts[len(xforms)] = translations(xforms)
+
+        # QuadA is instanced at points 0 and 2, QuadB at point 1
+        self.assertEqual(set(counts.keys()), {1, 2})
+        self.assertEqual(counts[2], [(0, 0, 0), (0, 5, 0)])
+        self.assertEqual(counts[1], [(5, 0, 0)])
+
+    def test_PointInstancerInvisibleIds(self):
+        # Masked instances are dropped from the transform list without
+        # renumbering the surviving ones.
+        stage = Usd.Stage.CreateInMemory()
+        pi = UsdGeom.PointInstancer.Define(stage, '/PI')
+        create_quad(stage, '/PI/Protos/Quad')
+        pi.CreatePrototypesRel().SetTargets([Sdf.Path('/PI/Protos/Quad')])
+        pi.CreateProtoIndicesAttr(Vt.IntArray([0, 0, 0]))
+        pi.CreatePositionsAttr(
+            Vt.Vec3fArray([(0, 0, 0), (5, 0, 0), (0, 5, 0)]))
+        pi.CreateInvisibleIdsAttr(Vt.Int64Array([1]))
+
+        data = render_extract(stage)
+        meshes = get_meshes(data)
+        self.assertEqual(len(meshes), 1)
+        mesh = meshes[0]
+
+        self.assertFalse(mesh.instancerId.isEmpty)
+        xforms = mesh.GetInstanceTransforms().GetValue()
+        self.assertEqual(translations(xforms), [(0, 0, 0), (0, 5, 0)])
+
+    def test_NativeInstancing(self):
+        # Two instanceable references to one prototype aggregate into a
+        # single mesh with two instance transforms.
+        stage = Usd.Stage.CreateInMemory()
+        stage.CreateClassPrim('/_Proto')
+        create_quad(stage, '/_Proto/Geom')
+
+        offsets = [(0, 0, 0), (5, 0, 0)]
+        for i, offset in enumerate(offsets):
+            xf = UsdGeom.Xform.Define(stage, '/Instance%d' % i)
+            xf.AddTranslateOp().Set(Gf.Vec3d(*offset))
+            prim = xf.GetPrim()
+            prim.GetReferences().AddInternalReference('/_Proto')
+            prim.SetInstanceable(True)
+
+        data = render_extract(stage)
+        meshes = get_meshes(data)
+        self.assertEqual(len(meshes), 1)
+        mesh = meshes[0]
+
+        self.assertFalse(mesh.instancerId.isEmpty)
+        xforms = mesh.GetInstanceTransforms().GetValue()
+        self.assertEqual(len(xforms), 2)
+        self.assertEqual(translations(xforms), sorted(offsets))
+
+    def test_NestedPointInstancers(self):
+        # A point instancer whose prototype contains another point
+        # instancer: the flattened transform list covers the cross product
+        # of both levels.
+        stage = Usd.Stage.CreateInMemory()
+        outer = UsdGeom.PointInstancer.Define(stage, '/Outer')
+        inner = UsdGeom.PointInstancer.Define(stage, '/Outer/Protos/Inner')
+        create_quad(stage, '/Outer/Protos/Inner/Protos/Quad')
+
+        inner.CreatePrototypesRel().SetTargets(
+            [Sdf.Path('/Outer/Protos/Inner/Protos/Quad')])
+        inner.CreateProtoIndicesAttr(Vt.IntArray([0, 0]))
+        inner_offsets = [(0, 0, 0), (1, 0, 0)]
+        inner.CreatePositionsAttr(Vt.Vec3fArray(inner_offsets))
+
+        outer.CreatePrototypesRel().SetTargets(
+            [Sdf.Path('/Outer/Protos/Inner')])
+        outer.CreateProtoIndicesAttr(Vt.IntArray([0, 0]))
+        outer_offsets = [(0, 0, 0), (0, 10, 0)]
+        outer.CreatePositionsAttr(Vt.Vec3fArray(outer_offsets))
+
+        data = render_extract(stage)
+        meshes = get_meshes(data)
+        self.assertEqual(len(meshes), 1)
+        mesh = meshes[0]
+
+        self.assertFalse(mesh.instancerId.isEmpty)
+        xforms = mesh.GetInstanceTransforms().GetValue()
+        self.assertEqual(len(xforms), 4)
+
+        expected = sorted(
+            (io[0] + oo[0], io[1] + oo[1], io[2] + oo[2])
+            for oo in outer_offsets for io in inner_offsets)
+        self.assertEqual(translations(xforms), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pxr/usdImaging/hydraPassthrough/testenv/testHydraPassthroughInstancing.py
+++ b/pxr/usdImaging/hydraPassthrough/testenv/testHydraPassthroughInstancing.py
@@ -59,6 +59,8 @@ class TestInstancing(unittest.TestCase):
         self.assertEqual(len(meshes), 1)
         self.assertTrue(meshes[0].instancerId.isEmpty)
         self.assertFalse(meshes[0].GetInstanceTransforms().GetValue())
+        self.assertFalse(meshes[0].GetInstanceIndices().GetValue())
+        self.assertEqual(meshes[0].GetAllInstancePrimvars(), [])
 
     def test_PointInstancer(self):
         # A point instancer with positions, orientations and scales, and a
@@ -105,6 +107,9 @@ class TestInstancing(unittest.TestCase):
         for got, want in zip(xforms, expected):
             self.assertMatrixClose(got, want * instancer_l2w)
 
+        # Instance indices are the point indices, parallel to the transforms
+        self.assertEqual(list(mesh.GetInstanceIndices().GetValue()), [0, 1, 2])
+
     def test_PointInstancerMultiplePrototypes(self):
         # Two prototypes sharing one instancer: each propagated mesh gets
         # the transforms for its own protoIndices entries.
@@ -135,7 +140,8 @@ class TestInstancing(unittest.TestCase):
 
     def test_PointInstancerInvisibleIds(self):
         # Masked instances are dropped from the transform list without
-        # renumbering the surviving ones.
+        # renumbering the surviving ones, and instance primvars are
+        # gathered by the same surviving indices.
         stage = Usd.Stage.CreateInMemory()
         pi = UsdGeom.PointInstancer.Define(stage, '/PI')
         create_quad(stage, '/PI/Protos/Quad')
@@ -145,6 +151,12 @@ class TestInstancing(unittest.TestCase):
             Vt.Vec3fArray([(0, 0, 0), (5, 0, 0), (0, 5, 0)]))
         pi.CreateInvisibleIdsAttr(Vt.Int64Array([1]))
 
+        colors = [(1, 0, 0), (0, 1, 0), (0, 0, 1)]
+        color_primvar = UsdGeom.PrimvarsAPI(pi).CreatePrimvar(
+            'displayColor', Sdf.ValueTypeNames.Color3fArray,
+            UsdGeom.Tokens.varying)
+        color_primvar.Set(Vt.Vec3fArray(colors))
+
         data = render_extract(stage)
         meshes = get_meshes(data)
         self.assertEqual(len(meshes), 1)
@@ -153,6 +165,62 @@ class TestInstancing(unittest.TestCase):
         self.assertFalse(mesh.instancerId.isEmpty)
         xforms = mesh.GetInstanceTransforms().GetValue()
         self.assertEqual(translations(xforms), [(0, 0, 0), (0, 5, 0)])
+
+        # Point 1 is masked: indices skip it, colors follow the indices
+        self.assertEqual(list(mesh.GetInstanceIndices().GetValue()), [0, 2])
+        color_out = mesh.GetInstancePrimvar('displayColor')
+        self.assertEqual(list(color_out.data.GetValue()),
+                         [Gf.Vec3f(*colors[0]), Gf.Vec3f(*colors[2])])
+
+    def test_InstancePrimvars(self):
+        # Primvars authored on a point instancer (other than the transform
+        # builders) pass through as instance primvars, gathered per drawn
+        # instance. Constant primvars stay constant and are excluded.
+        stage = Usd.Stage.CreateInMemory()
+        pi = UsdGeom.PointInstancer.Define(stage, '/PI')
+        create_quad(stage, '/PI/Protos/Quad')
+        pi.CreatePrototypesRel().SetTargets([Sdf.Path('/PI/Protos/Quad')])
+        pi.CreateProtoIndicesAttr(Vt.IntArray([0, 0, 0]))
+        pi.CreatePositionsAttr(
+            Vt.Vec3fArray([(0, 0, 0), (5, 0, 0), (0, 5, 0)]))
+        pi.CreateScalesAttr(
+            Vt.Vec3fArray([(1, 1, 1), (2, 2, 2), (3, 3, 3)]))
+
+        primvars = UsdGeom.PrimvarsAPI(pi)
+        colors = [(1, 0, 0), (0, 1, 0), (0, 0, 1)]
+        primvars.CreatePrimvar(
+            'displayColor', Sdf.ValueTypeNames.Color3fArray,
+            UsdGeom.Tokens.varying).Set(Vt.Vec3fArray(colors))
+        floats = [1.5, 2.5, 3.5]
+        primvars.CreatePrimvar(
+            'myFloat', Sdf.ValueTypeNames.FloatArray,
+            UsdGeom.Tokens.varying).Set(Vt.FloatArray(floats))
+        primvars.CreatePrimvar(
+            'myConstant', Sdf.ValueTypeNames.Float,
+            UsdGeom.Tokens.constant).Set(42.0)
+
+        data = render_extract(stage)
+        meshes = get_meshes(data)
+        self.assertEqual(len(meshes), 1)
+        mesh = meshes[0]
+
+        names = sorted(pv.name for pv in mesh.GetAllInstancePrimvars())
+        self.assertEqual(names, ['displayColor', 'myFloat'])
+
+        color_out = mesh.GetInstancePrimvar('displayColor')
+        self.assertEqual(color_out.interpolation, 'instance')
+        self.assertEqual(list(color_out.data.GetValue()),
+                         [Gf.Vec3f(*c) for c in colors])
+
+        float_out = mesh.GetInstancePrimvar('myFloat')
+        self.assertEqual(float_out.interpolation, 'instance')
+        self.assertEqual(list(float_out.data.GetValue()), floats)
+
+        # The transform builders are baked into the matrices, not primvars
+        self.assertIsNone(
+            mesh.GetInstancePrimvar('hydra:instanceTranslations'))
+        self.assertIsNone(mesh.GetInstancePrimvar('hydra:instanceScales'))
+        self.assertIsNone(mesh.GetInstancePrimvar('myConstant'))
 
     def test_NativeInstancing(self):
         # Two instanceable references to one prototype aggregate into a
@@ -179,10 +247,17 @@ class TestInstancing(unittest.TestCase):
         self.assertEqual(len(xforms), 2)
         self.assertEqual(translations(xforms), sorted(offsets))
 
+        # Aggregated native instances get sequential indices and carry no
+        # instance primvars (their transforms are the only instance data)
+        self.assertEqual(sorted(mesh.GetInstanceIndices().GetValue()), [0, 1])
+        self.assertEqual(mesh.GetAllInstancePrimvars(), [])
+
     def test_NestedPointInstancers(self):
         # A point instancer whose prototype contains another point
-        # instancer: the flattened transform list covers the cross product
-        # of both levels.
+        # instancer: the flattened data covers the cross product of both
+        # levels, ordered outer-major. Instance indices identify the inner
+        # (closest to the prototype) level; inner primvars repeat per outer
+        # instance and outer primvars expand over each inner block.
         stage = Usd.Stage.CreateInMemory()
         outer = UsdGeom.PointInstancer.Define(stage, '/Outer')
         inner = UsdGeom.PointInstancer.Define(stage, '/Outer/Protos/Inner')
@@ -193,12 +268,20 @@ class TestInstancing(unittest.TestCase):
         inner.CreateProtoIndicesAttr(Vt.IntArray([0, 0]))
         inner_offsets = [(0, 0, 0), (1, 0, 0)]
         inner.CreatePositionsAttr(Vt.Vec3fArray(inner_offsets))
+        inner_floats = [1.5, 2.5]
+        UsdGeom.PrimvarsAPI(inner).CreatePrimvar(
+            'myFloat', Sdf.ValueTypeNames.FloatArray,
+            UsdGeom.Tokens.varying).Set(Vt.FloatArray(inner_floats))
 
         outer.CreatePrototypesRel().SetTargets(
             [Sdf.Path('/Outer/Protos/Inner')])
         outer.CreateProtoIndicesAttr(Vt.IntArray([0, 0]))
         outer_offsets = [(0, 0, 0), (0, 10, 0)]
         outer.CreatePositionsAttr(Vt.Vec3fArray(outer_offsets))
+        outer_colors = [(1, 0, 0), (0, 1, 0)]
+        UsdGeom.PrimvarsAPI(outer).CreatePrimvar(
+            'displayColor', Sdf.ValueTypeNames.Color3fArray,
+            UsdGeom.Tokens.varying).Set(Vt.Vec3fArray(outer_colors))
 
         data = render_extract(stage)
         meshes = get_meshes(data)
@@ -209,10 +292,29 @@ class TestInstancing(unittest.TestCase):
         xforms = mesh.GetInstanceTransforms().GetValue()
         self.assertEqual(len(xforms), 4)
 
-        expected = sorted(
+        # Flattened outer-major: all inner instances of outer 0, then of
+        # outer 1
+        expected = [
             (io[0] + oo[0], io[1] + oo[1], io[2] + oo[2])
-            for oo in outer_offsets for io in inner_offsets)
-        self.assertEqual(translations(xforms), expected)
+            for oo in outer_offsets for io in inner_offsets]
+        got = [tuple(round(c, 3) for c in x.ExtractTranslation())
+               for x in xforms]
+        self.assertEqual(got, expected)
+
+        # Inner-level indices, repeated per outer instance
+        self.assertEqual(list(mesh.GetInstanceIndices().GetValue()),
+                         [0, 1, 0, 1])
+
+        # Inner primvar repeats per outer instance
+        float_out = mesh.GetInstancePrimvar('myFloat')
+        self.assertEqual(list(float_out.data.GetValue()),
+                         inner_floats + inner_floats)
+
+        # Outer primvar expands over each inner block
+        color_out = mesh.GetInstancePrimvar('displayColor')
+        self.assertEqual(
+            list(color_out.data.GetValue()),
+            [Gf.Vec3f(*outer_colors[0])] * 2 + [Gf.Vec3f(*outer_colors[1])] * 2)
 
 
 if __name__ == "__main__":

--- a/pxr/usdImaging/hydraPassthrough/wrapRenderData.cpp
+++ b/pxr/usdImaging/hydraPassthrough/wrapRenderData.cpp
@@ -99,6 +99,12 @@ namespace {
         return HydraPassthroughValueDescriptor(self.edgeIndices);
     }
 
+    HydraPassthroughValueDescriptor _GetMeshInstanceTransforms(
+        const HydraPassthroughRenderData::MeshData &self)
+    {
+        return HydraPassthroughValueDescriptor(VtValue(self.instanceTransforms));
+    }
+
     // Need this to be a function so that it can use TfPySequenceToList
     // return_value_policy.
     const std::vector<GfVec4d> &_GetClippingPlanes(
@@ -280,6 +286,9 @@ wrapRenderData()
         .def("GetFaceVertexIndices", ::_GetMeshFaceVertexIndices)
         .def("GetPrimitiveParams", ::_GetMeshPrimitiveParams)
         .def("GetEdgeIndices", ::_GetMeshEdgeIndices)
+
+        .def_readonly("instancerId", &This::MeshData::instancerId)
+        .def("GetInstanceTransforms", ::_GetMeshInstanceTransforms)
         ;
 
     enum_<This::MaterialData::MaterialType>("MaterialType")

--- a/pxr/usdImaging/hydraPassthrough/wrapRenderData.cpp
+++ b/pxr/usdImaging/hydraPassthrough/wrapRenderData.cpp
@@ -105,6 +105,12 @@ namespace {
         return HydraPassthroughValueDescriptor(VtValue(self.instanceTransforms));
     }
 
+    HydraPassthroughValueDescriptor _GetMeshInstanceIndices(
+        const HydraPassthroughRenderData::MeshData &self)
+    {
+        return HydraPassthroughValueDescriptor(VtValue(self.instanceIndices));
+    }
+
     // Need this to be a function so that it can use TfPySequenceToList
     // return_value_policy.
     const std::vector<GfVec4d> &_GetClippingPlanes(
@@ -191,6 +197,28 @@ namespace {
     {
         auto it = self.primvars.find(name);
         if (it != self.primvars.end()) {
+            return Primvar(name, it->second);
+        }
+        return {};
+    }
+
+    std::vector<Primvar> _GetAllInstancePrimvars(
+        const HydraPassthroughRenderData::MeshData &self)
+    {
+        std::vector<Primvar> result;
+        result.reserve(self.instancePrimvars.size());
+        for (const auto &it : self.instancePrimvars) {
+            result.emplace_back(it.first, it.second);
+        }
+        return result;
+    }
+
+    std::optional<Primvar> _GetInstancePrimvar(
+        const HydraPassthroughRenderData::MeshData &self,
+        const TfToken &name)
+    {
+        auto it = self.instancePrimvars.find(name);
+        if (it != self.instancePrimvars.end()) {
             return Primvar(name, it->second);
         }
         return {};
@@ -289,6 +317,10 @@ wrapRenderData()
 
         .def_readonly("instancerId", &This::MeshData::instancerId)
         .def("GetInstanceTransforms", ::_GetMeshInstanceTransforms)
+        .def("GetInstanceIndices", ::_GetMeshInstanceIndices)
+        .def("GetAllInstancePrimvars", &_GetAllInstancePrimvars,
+             return_value_policy<TfPySequenceToList>())
+        .def("GetInstancePrimvar", &_GetInstancePrimvar, (arg("name")))
         ;
 
     enum_<This::MaterialData::MaterialType>("MaterialType")

--- a/pxr/usdImaging/hydraPassthrough/wrapRenderData.cpp
+++ b/pxr/usdImaging/hydraPassthrough/wrapRenderData.cpp
@@ -229,6 +229,12 @@ namespace {
     {
         return self.faceVaryingChannels;
     }
+
+    const std::map<int, SdfPath> &_GetInstanceOriginPaths(
+        const HydraPassthroughRenderData::SceneGraphInstancerData &self)
+    {
+        return self.instanceOriginPaths;
+    }
 }
 
 void
@@ -253,6 +259,13 @@ wrapRenderData()
              return_internal_reference())
         .def("GetMaterialCount", &This::GetMaterialCount)
         .def("GetMaterialByIndex", &This::GetMaterialByIndex,
+             (arg("index")),
+             return_internal_reference())
+        .def("GetSceneGraphInstancer", &This::GetSceneGraphInstancer,
+             (arg("id")),
+             return_internal_reference())
+        .def("GetSceneGraphInstancerCount", &This::GetSceneGraphInstancerCount)
+        .def("GetSceneGraphInstancerByIndex", &This::GetSceneGraphInstancerByIndex,
              (arg("index")),
              return_internal_reference())
 
@@ -282,6 +295,21 @@ wrapRenderData()
         .def("GetMaterialByIndex", &This::RenderData::GetMaterialByIndex,
              (arg("index")),
              return_internal_reference())
+        .def("GetSceneGraphInstancer", &This::RenderData::GetSceneGraphInstancer,
+             (arg("id")),
+             return_internal_reference())
+        .def("GetSceneGraphInstancerCount",
+             &This::RenderData::GetSceneGraphInstancerCount)
+        .def("GetSceneGraphInstancerByIndex",
+             &This::RenderData::GetSceneGraphInstancerByIndex,
+             (arg("index")),
+             return_internal_reference())
+        ;
+
+    class_<This::SceneGraphInstancerData>("SceneGraphInstancerData", no_init)
+        .def_readonly("id", &This::SceneGraphInstancerData::id)
+        .def("GetInstanceOriginPaths", ::_GetInstanceOriginPaths,
+             return_value_policy<TfPyMapToDictionary>())
         ;
 
     class_<Primvar>("Primvar", no_init)


### PR DESCRIPTION
This change enables instancing with transforms only, other primvars and ids are not propagated yet. We're relying on the hydra 2.0 scene indices preparing instance information upstream, once instances reach our render delegate there is no difference between point and scene graph instancers.

instancer.h/cpp is largely based on the HdEmbree example.

Instance information is returned on the MeshData class directly. A normal mesh will have instancerId set to an empty path, and instanceTransforms will be an empty array. For an instanced mesh, these will be populated with an instancer path, and a per-instance xform.