### PR TITLE
Capture geom subsets at sync time for later processing

### DIFF
--- a/pxr/usdImaging/hydraPassthrough/CMakeLists.txt
+++ b/pxr/usdImaging/hydraPassthrough/CMakeLists.txt
@@ -85,6 +85,7 @@ pxr_build_test(testHydraPassthroughValueDescriptor
 
 pxr_test_scripts(
     testenv/testHydraPassthroughCameraData.py
+    testenv/testHydraPassthroughGeomSubsets.py
     testenv/testHydraPassthroughInstancing.py
     testenv/testHydraPassthroughMeshData.py
     testenv/testHydraPassthroughMaterialData.py
@@ -123,6 +124,12 @@ pxr_register_test(testHydraPassthroughSkinning
 pxr_register_test(testHydraPassthroughSubdivision
     PYTHON
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHydraPassthroughSubdivision"
+    EXPECTED_RETURN_CODE 0
+)
+
+pxr_register_test(testHydraPassthroughGeomSubsets
+    PYTHON
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHydraPassthroughGeomSubsets"
     EXPECTED_RETURN_CODE 0
 )
 

--- a/pxr/usdImaging/hydraPassthrough/mesh.cpp
+++ b/pxr/usdImaging/hydraPassthrough/mesh.cpp
@@ -382,11 +382,28 @@ HydraPassthroughMesh::_UpdateTopologyDependentComputations(
         resourceRegistry->AddGenericSource(id, quadInfoBuilder);
     }
 
-    const HdGeomSubsets &geomSubsets = _topology.GetGeomSubsets();
+    // Record geom subsets for the output data. Unlike HdSt, which builds a
+    // separate draw item and index buffer per subset, we build the single
+    // index buffer below regardless of subsets. Our primitiveParam always
+    // decodes to the authored coarse face (for the triangulated,
+    // quadrangulated, and refined paths alike), so packaging can map fine
+    // primitives back to subsets when building per-material draw groups.
+    //
+    // Subset changes, including material rebinds on the subset prim, reach
+    // us as DirtyTopology (see HdSceneIndexAdapterSceneDelegate, which marks
+    // the parent rprim's topology dirty for any dirtied geomSubset prim), so
+    // refreshing here keeps these current. The points geom style draws the
+    // coarse points and ignores subsets, as HdSt does.
+    _meshData.geomSubsets.clear();
+    if (desc.geomStyle != HdMeshGeomStylePoints) {
+        for (const HdGeomSubset &geomSubset : _topology.GetGeomSubsets()) {
+            _meshData.geomSubsets.push_back(
+                {geomSubset.id, geomSubset.materialId, geomSubset.indices});
+        }
+    }
 
-    // Normal case
-    if (geomSubsets.empty() || desc.geomStyle == HdMeshGeomStylePoints) {
-
+    // Create index buffer source for the current representation.
+    {
         HdBufferSourceSharedPtrVector sources;
         HdBufferSourceSharedPtr source;
 
@@ -406,10 +423,10 @@ HydraPassthroughMesh::_UpdateTopologyDependentComputations(
             // Add computations for face varying primvar indices
             if (_topology.GetSubdivTags().GetFaceVaryingInterpolationRule() !=
                     PxOsdOpenSubdivTokens->all) {
-                for (size_t i = 0; 
-                        i < _fvarTopologyTracker.GetNumTopologies(); 
+                for (size_t i = 0;
+                        i < _fvarTopologyTracker.GetNumTopologies();
                         ++i) {
-                    HdBufferSourceSharedPtr fvarIndicesSource = 
+                    HdBufferSourceSharedPtr fvarIndicesSource =
                         _topology.GetOsdFvarIndexBuilderComputation(i);
                     sources.push_back(fvarIndicesSource);
                 }
@@ -422,18 +439,10 @@ HydraPassthroughMesh::_UpdateTopologyDependentComputations(
         } else {
             // create triangle indices, primitiveParam and edgeIndices
             source = _topology.GetTriangleIndexBuilderComputation(id);
-            sources.push_back(source);  
+            sources.push_back(source);
         }
 
         resourceRegistry->AddIndexSources(id, std::move(sources));
-
-    } else {
-        // XXX will handle later, need test data
-        // Geom subsets case
-        // See HdStMesh::Sync for the similar if/else to this block, we can base
-        // the implementation on that, but using local implementations
-        // It will likely require updating our output format as well.
-        HF_VALIDATION_WARN(id, "Geom subsets not supported yet");
     }
 
     // Now populate primvar sources and computations that we need.
@@ -450,9 +459,6 @@ HydraPassthroughMesh::_UpdateTopologyDependentComputations(
             dirtyBits,
             &requireSmoothNormals,
             &requireFlatNormals);
-
-    // temp, replace with real subset once supported
-    const int geomSubsetDescIndex = 0;
 
     // Get the only draw item we created
     HdDrawItem *drawItem = repr->GetDrawItem(0);
@@ -498,7 +504,7 @@ HydraPassthroughMesh::_UpdateTopologyDependentComputations(
         HdChangeTracker::IsAnyPrimvarDirty(*dirtyBits, id)) {
         MeshUtil::PopulateVertexAndVaryingPrimvars(
                 this, id, sceneDelegate, resourceRegistry.get(), &_topology,
-                _vertexAdjacencyBuilder.get(), desc, drawItem, geomSubsetDescIndex,
+                _vertexAdjacencyBuilder.get(), desc, drawItem,
                 dirtyBits, requireSmoothNormals);
     }
 

--- a/pxr/usdImaging/hydraPassthrough/meshPackagingUtil.cpp
+++ b/pxr/usdImaging/hydraPassthrough/meshPackagingUtil.cpp
@@ -248,9 +248,13 @@ BuildDrawGroups(HydraPassthroughRenderData::MeshData* meshData)
     const size_t numPrims = primFaceIndices.size();
     const size_t cornersPerPrim = numCorners / numPrims;
 
-    // Assign each authored face to the subset that lists it (sanitizing
-    // already removed duplicates between subsets). Faces in no subset form
-    // the trailing remainder group, drawn with the mesh's own material.
+    // Assign each authored face to the subset that lists it. Sanitizing
+    // warns about faces repeated between subsets but keeps them, so
+    // collisions are possible here: the first subset listing a face wins
+    // (emplace keeps the existing entry). We don't warn again; sync
+    // already did, and extraction can run many times per render. Faces in
+    // no subset form the trailing remainder group, drawn with the mesh's
+    // own material.
     const size_t numSubsets = meshData->geomSubsets.size();
     const size_t remainderGroup = numSubsets;
     const size_t numGroups = numSubsets + 1;
@@ -328,11 +332,10 @@ BuildDrawGroups(HydraPassthroughRenderData::MeshData* meshData)
         // Refined face-varying channels hold one index entry per patch.
         // Their compact value buffers are addressed through these indices
         // and stay put.
-        std::vector<TfToken> channelPrimvars;
+        TfToken::HashSet channelPrimvars;
         for (HydraPassthroughRenderData::FaceVaryingChannel& channel :
                 meshData->faceVaryingChannels) {
-            channelPrimvars.insert(channelPrimvars.end(),
-                                   channel.primvars.begin(),
+            channelPrimvars.insert(channel.primvars.begin(),
                                    channel.primvars.end());
             if (channel.indices.GetArraySize() == numPrims) {
                 channel.indices = _GatherElements(channel.indices, primOrder);
@@ -350,8 +353,7 @@ BuildDrawGroups(HydraPassthroughRenderData::MeshData* meshData)
             HydraPassthroughRenderData::PrimvarData& primvar =
                 primvarEntry.second;
             if (primvar.interpolation != HdInterpolationFaceVarying ||
-                std::find(channelPrimvars.begin(), channelPrimvars.end(),
-                          primvarEntry.first) != channelPrimvars.end()) {
+                channelPrimvars.count(primvarEntry.first)) {
                 continue;
             }
             if (primvar.data.GetArraySize() != numCorners) {

--- a/pxr/usdImaging/hydraPassthrough/meshPackagingUtil.cpp
+++ b/pxr/usdImaging/hydraPassthrough/meshPackagingUtil.cpp
@@ -100,17 +100,14 @@ _FlattenFvarIndices(
     return false;
 }
 
-// Builds one coarse-face index per corner so uniform (per-face) primvars
-// can be expanded. primitiveParam has one entry per triangle for unrefined
+// Decodes primitiveParam into one authored (coarse) face index per fine
+// primitive. primitiveParam has one entry per triangle for unrefined
 // meshes (int) and one entry per patch for refined meshes (GfVec3i with
-// the encoded param in element [0]). The number of corners per entry
-// (3 for triangles, 6 for triangulated quads) falls out of the buffer
-// sizes.
+// the encoded param in element [0]).
 bool
-_BuildUniformCornerIndices(
+_DecodePrimitiveFaceIndices(
     const VtValue& primitiveParam,
-    size_t numCorners,
-    VtIntArray* cornerIndices)
+    VtIntArray* faceIndices)
 {
     VtIntArray encodedParams;
     if (primitiveParam.IsHolding<VtIntArray>()) {
@@ -126,19 +123,39 @@ _BuildUniformCornerIndices(
         return false;
     }
 
-    if (encodedParams.empty() || numCorners % encodedParams.size() != 0) {
+    faceIndices->resize(encodedParams.size());
+    int* dst = faceIndices->data();
+    for (const int encodedParam : encodedParams) {
+        *dst++ = HdMeshUtil::DecodeFaceIndexFromCoarseFaceParam(encodedParam);
+    }
+    return true;
+}
+
+// Builds one coarse-face index per corner so uniform (per-face) primvars
+// can be expanded. The number of corners per primitive (3 for triangles,
+// 6 for triangulated quads) falls out of the buffer sizes.
+bool
+_BuildUniformCornerIndices(
+    const VtValue& primitiveParam,
+    size_t numCorners,
+    VtIntArray* cornerIndices)
+{
+    VtIntArray faceIndices;
+    if (!_DecodePrimitiveFaceIndices(primitiveParam, &faceIndices)) {
         return false;
     }
-    const size_t cornersPerEntry = numCorners / encodedParams.size();
+
+    if (faceIndices.empty() || numCorners % faceIndices.size() != 0) {
+        return false;
+    }
+    const size_t cornersPerEntry = numCorners / faceIndices.size();
     if (cornersPerEntry != 3 && cornersPerEntry != 6) {
         return false;
     }
 
     cornerIndices->resize(numCorners);
     int* dst = cornerIndices->data();
-    for (const int encodedParam : encodedParams) {
-        const int faceIndex =
-            HdMeshUtil::DecodeFaceIndexFromCoarseFaceParam(encodedParam);
+    for (const int faceIndex : faceIndices) {
         for (size_t corner = 0; corner < cornersPerEntry; ++corner) {
             *dst++ = faceIndex;
         }
@@ -202,6 +219,168 @@ struct _CornerKeyHash {
 
 namespace HydraPassthroughMeshPackagingUtil
 {
+
+void
+BuildDrawGroups(HydraPassthroughRenderData::MeshData* meshData)
+{
+    meshData->drawGroups.clear();
+    if (meshData->geomSubsets.empty()) {
+        return;
+    }
+
+    // Every fine primitive maps back to the authored face it came from
+    // through primitiveParam, and geom subsets are lists of authored
+    // faces, so decoding primitiveParam assigns each primitive to its
+    // subset. Holes are handled implicitly: no primitive decodes to a
+    // hole face.
+    const size_t numCorners = meshData->faceVertexIndices.size();
+    VtIntArray primFaceIndices;
+    if (numCorners == 0 ||
+        !_DecodePrimitiveFaceIndices(meshData->primitiveParam,
+                                     &primFaceIndices) ||
+        primFaceIndices.empty() ||
+        numCorners % primFaceIndices.size() != 0) {
+        TF_WARN("Could not map primitives to faces for %s; geom subsets "
+                "will not be exported as draw groups",
+                meshData->id.GetText());
+        return;
+    }
+    const size_t numPrims = primFaceIndices.size();
+    const size_t cornersPerPrim = numCorners / numPrims;
+
+    // Assign each authored face to the subset that lists it (sanitizing
+    // already removed duplicates between subsets). Faces in no subset form
+    // the trailing remainder group, drawn with the mesh's own material.
+    const size_t numSubsets = meshData->geomSubsets.size();
+    const size_t remainderGroup = numSubsets;
+    const size_t numGroups = numSubsets + 1;
+    std::unordered_map<int, size_t> faceToGroup;
+    for (size_t subset = 0; subset < numSubsets; ++subset) {
+        for (const int face : meshData->geomSubsets[subset].faceIndices) {
+            faceToGroup.emplace(face, subset);
+        }
+    }
+
+    std::vector<size_t> primGroups(numPrims);
+    std::vector<size_t> groupCounts(numGroups, 0);
+    for (size_t prim = 0; prim < numPrims; ++prim) {
+        const auto groupIt = faceToGroup.find(primFaceIndices[prim]);
+        primGroups[prim] =
+            groupIt == faceToGroup.end() ? remainderGroup : groupIt->second;
+        groupCounts[primGroups[prim]]++;
+    }
+
+    std::vector<size_t> groupOffsets(numGroups, 0);
+    for (size_t group = 1; group < numGroups; ++group) {
+        groupOffsets[group] = groupOffsets[group - 1] + groupCounts[group - 1];
+    }
+
+    // Order the primitives by group, stably: primOrder[newPrim] = oldPrim.
+    VtIntArray primOrder(numPrims);
+    bool identity = true;
+    {
+        std::vector<size_t> next = groupOffsets;
+        for (size_t prim = 0; prim < numPrims; ++prim) {
+            const size_t pos = next[primGroups[prim]]++;
+            primOrder[pos] = (int)prim;
+            identity = identity && (pos == prim);
+        }
+    }
+
+    if (!identity) {
+        // Reorder everything that is parallel to the primitives (one entry
+        // per primitive) or to their corners. Data addressed through the
+        // reordered buffers stays put: points and vertex/varying primvars
+        // are indexed by the values of faceVertexIndices, and uniform
+        // primvars stay in authored face order, addressed by decoding the
+        // reordered primitiveParam.
+        VtIntArray cornerOrder(numCorners);
+        for (size_t prim = 0; prim < numPrims; ++prim) {
+            const size_t oldFirstCorner = primOrder[prim] * cornersPerPrim;
+            for (size_t corner = 0; corner < cornersPerPrim; ++corner) {
+                cornerOrder[prim * cornersPerPrim + corner] =
+                    (int)(oldFirstCorner + corner);
+            }
+        }
+
+        VtIntArray sortedIndices(numCorners);
+        const int* srcIndices = meshData->faceVertexIndices.cdata();
+        for (size_t corner = 0; corner < numCorners; ++corner) {
+            sortedIndices[corner] = srcIndices[cornerOrder[corner]];
+        }
+        meshData->faceVertexIndices = sortedIndices;
+
+        meshData->primitiveParam =
+            _GatherElements(meshData->primitiveParam, primOrder);
+
+        if (!meshData->edgeIndices.IsEmpty()) {
+            if (meshData->edgeIndices.GetArraySize() == numPrims) {
+                meshData->edgeIndices =
+                    _GatherElements(meshData->edgeIndices, primOrder);
+            } else {
+                TF_WARN("Edge indices of %s are not per-primitive; dropping "
+                        "them from the draw-grouped copy",
+                        meshData->id.GetText());
+                meshData->edgeIndices = VtValue();
+            }
+        }
+
+        // Refined face-varying channels hold one index entry per patch.
+        // Their compact value buffers are addressed through these indices
+        // and stay put.
+        std::vector<TfToken> channelPrimvars;
+        for (HydraPassthroughRenderData::FaceVaryingChannel& channel :
+                meshData->faceVaryingChannels) {
+            channelPrimvars.insert(channelPrimvars.end(),
+                                   channel.primvars.begin(),
+                                   channel.primvars.end());
+            if (channel.indices.GetArraySize() == numPrims) {
+                channel.indices = _GatherElements(channel.indices, primOrder);
+            } else {
+                TF_WARN("Face-varying channel %d of %s has indices that "
+                        "don't match the mesh's primitives; its primvars "
+                        "will misalign with the draw groups",
+                        channel.channel, meshData->id.GetText());
+            }
+        }
+
+        // Unrefined face-varying primvars have no channel and are already
+        // per-corner, so their values move with the corners.
+        for (auto& primvarEntry : meshData->primvars) {
+            HydraPassthroughRenderData::PrimvarData& primvar =
+                primvarEntry.second;
+            if (primvar.interpolation != HdInterpolationFaceVarying ||
+                std::find(channelPrimvars.begin(), channelPrimvars.end(),
+                          primvarEntry.first) != channelPrimvars.end()) {
+                continue;
+            }
+            if (primvar.data.GetArraySize() != numCorners) {
+                TF_WARN("Face-varying primvar %s of %s has %zu values, "
+                        "expected %zu; it will misalign with the draw "
+                        "groups",
+                        primvarEntry.first.GetText(),
+                        meshData->id.GetText(),
+                        primvar.data.GetArraySize(), numCorners);
+                continue;
+            }
+            primvar.data = _GatherElements(primvar.data, cornerOrder);
+        }
+    }
+
+    // Emit the groups in index elements. Subsets that ended up with no
+    // primitives (e.g. all their faces are holes) produce no group.
+    for (size_t group = 0; group < numGroups; ++group) {
+        if (groupCounts[group] == 0) {
+            continue;
+        }
+        meshData->drawGroups.push_back(
+            {group == remainderGroup
+                 ? meshData->materialId
+                 : meshData->geomSubsets[group].materialId,
+             (int)(groupOffsets[group] * cornersPerPrim),
+             (int)(groupCounts[group] * cornersPerPrim)});
+    }
+}
 
 void
 DeindexMesh(HydraPassthroughRenderData::MeshData* meshData)

--- a/pxr/usdImaging/hydraPassthrough/meshPackagingUtil.h
+++ b/pxr/usdImaging/hydraPassthrough/meshPackagingUtil.h
@@ -9,6 +9,18 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 namespace HydraPassthroughMeshPackagingUtil
 {
+    /// Converts the mesh's geom subsets into draw groups: reorders the
+    /// fine primitives (and everything parallel to them) so each subset
+    /// occupies a contiguous range of faceVertexIndices, then populates
+    /// drawGroups with one entry per non-empty subset plus a trailing
+    /// group, bound to the mesh's own material, for faces in no subset.
+    ///
+    /// No-op for meshes without geom subsets. Run this before DeindexMesh
+    /// or WeldMesh; both preserve corner order, so the groups stay valid
+    /// across them.
+    void
+    BuildDrawGroups(HydraPassthroughRenderData::MeshData* meshData);
+
     /// Rewrites the mesh so that every non-constant primvar holds one value per
     /// corner of faceVertexIndices, in corner order, and faceVertexIndices
     /// becomes the identity. The result needs only a single (trivial) index

--- a/pxr/usdImaging/hydraPassthrough/meshUtil.cpp
+++ b/pxr/usdImaging/hydraPassthrough/meshUtil.cpp
@@ -208,7 +208,6 @@ void
 _GatherFaceVaryingTopologies(
         HdRprim const *rprim,
         HdSceneDelegate *sceneDelegate,
-        int geomSubsetDescIndex,
         HdDirtyBits *dirtyBits,
         const SdfPath &id,
         HydraPassthroughMeshTopology *topology,
@@ -319,13 +318,14 @@ void PopulateMeshTopology(
         std::move(HydraPassthroughMeshTopology(meshTopology, refineLevel, refineMode,
             HydraPassthroughMeshTopology::QuadsTriangulated));
     
-    // HdSt creates draw items for geom subsets here
+    // HdSt creates draw items for geom subsets here. We never create
+    // subset draw items; geom subsets are exported as draw groups over
+    // the shared index buffer instead (see HydraPassthroughMesh sync).
 
     if (refineLevel > 0) {
         finalTopology->SetSubdivTags(sceneDelegate->GetSubdivTags(id));
     }
 
-    const int geomSubsetDescIndex = 0; // temp, replace with real subset once supported
     TfToken fvarLinearInterpRule =
         finalTopology->GetSubdivTags().GetFaceVaryingInterpolationRule();
 
@@ -338,8 +338,8 @@ void PopulateMeshTopology(
         updatePrimvars) {
 
         _GatherFaceVaryingTopologies(
-            rprim, sceneDelegate, geomSubsetDescIndex, 
-                dirtyBits, id, finalTopology, fvarTopologyTracker);
+            rprim, sceneDelegate, dirtyBits, id, finalTopology,
+            fvarTopologyTracker);
         finalTopology->SetFvarTopologies(
             fvarTopologyTracker->GetFvarTopologies());
     }
@@ -355,7 +355,6 @@ PopulateVertexAndVaryingPrimvars(
         HydraPassthroughVertexAdjacencyBuilder *vertexAdjacencyBuilder,
         const HdMeshReprDesc &desc,
         HdDrawItem *drawItem,
-        int geomSubsetDescIndex,
         HdDirtyBits *dirtyBits,
         bool requireSmoothNormals)
 {

--- a/pxr/usdImaging/hydraPassthrough/meshUtil.h
+++ b/pxr/usdImaging/hydraPassthrough/meshUtil.h
@@ -37,7 +37,6 @@ namespace HydraPassthroughMeshUtil
         HydraPassthroughVertexAdjacencyBuilder *vertexAdjacencyBuilder,
         const HdMeshReprDesc &desc,
         HdDrawItem *drawItem,
-        int geomSubsetDescIndex,
         HdDirtyBits *dirtyBits,
         bool requireSmoothNormals);
 

--- a/pxr/usdImaging/hydraPassthrough/renderData.cpp
+++ b/pxr/usdImaging/hydraPassthrough/renderData.cpp
@@ -411,11 +411,23 @@ HydraPassthroughRenderData::CopyPrimvarBufferSource(
 
 HydraPassthroughRenderData::RenderData
 HydraPassthroughRenderData::ExtractRenderDataCopy() const {
-    const std::lock_guard<std::mutex> lock1(_meshMutex);
-    const std::lock_guard<std::mutex> lock2(_cameraMutex);
-    const std::lock_guard<std::mutex> lock3(_materialMutex);
-    const std::lock_guard<std::mutex> lock4(_instancerMutex);
-    return _renderData;
+    RenderData renderData;
+    {
+        const std::lock_guard<std::mutex> lock1(_meshMutex);
+        const std::lock_guard<std::mutex> lock2(_cameraMutex);
+        const std::lock_guard<std::mutex> lock3(_materialMutex);
+        const std::lock_guard<std::mutex> lock4(_instancerMutex);
+        renderData = _renderData;
+    }
+
+    // Geom subsets become per-material draw groups in every extracted
+    // copy. This reorders each mesh's primitives so a subset is a
+    // contiguous range of the index buffer; the deindexed and welded
+    // copies below inherit the groups since both preserve corner order.
+    for (auto& meshEntry : renderData.meshes) {
+        PackagingUtil::BuildDrawGroups(&meshEntry.second);
+    }
+    return renderData;
 }
 
 HydraPassthroughRenderData::RenderData

--- a/pxr/usdImaging/hydraPassthrough/renderData.h
+++ b/pxr/usdImaging/hydraPassthrough/renderData.h
@@ -128,7 +128,13 @@ public:
         GfMatrix4d transformInverse;
         VtValue points;
         VtValue normals;
-        VtIntArray faceVertexIndices; // triangles only
+        // Triangulated indices, three per triangle, always. Note though
+        // that primitiveParam and edgeIndices hold one entry per fine
+        // *primitive*, which is not always one triangle: quads (from
+        // quadrangulation or catmark/bilinear refinement) are split into
+        // two consecutive triangles here (HdMeshTriQuadBuilder order), so
+        // each of their entries covers six indices instead of three.
+        VtIntArray faceVertexIndices;
         VtValue primitiveParam;
         VtValue edgeIndices;
         TfHashMap<TfToken, PrimvarData, TfToken::HashFunctor> primvars;

--- a/pxr/usdImaging/hydraPassthrough/renderData.h
+++ b/pxr/usdImaging/hydraPassthrough/renderData.h
@@ -89,6 +89,35 @@ public:
         std::vector<TfToken> primvars;
     };
 
+    // A geom subset binds a material to a subset of a mesh's faces. This
+    // holds one subset as recorded at sync time: the authored (coarse) face
+    // indices it covers, already sanitized by
+    // HydraPassthroughMeshTopology::SanitizeGeomSubsets (out-of-range and
+    // duplicate faces removed, empty subsets dropped). Faces not covered by
+    // any subset are drawn with the mesh's own materialId.
+    struct GeomSubsetData {
+        SdfPath id;
+        SdfPath materialId;
+        VtIntArray faceIndices;
+    };
+
+    // A partial material binding in renderer terms: draw the contiguous
+    // range of the mesh's index buffer [start, start + count) with
+    // materialId. start and count are in index elements (three values per
+    // triangle), matching three.js geometry group conventions.
+    //
+    // Draw groups are only populated in extracted copies (see
+    // ExtractRenderDataCopy and friends), which reorder the mesh's
+    // primitives so that each geom subset occupies a contiguous range.
+    // Every group has a concrete materialId; faces in no subset get a
+    // group with the mesh's materialId. An empty drawGroups means the
+    // whole mesh is drawn with the mesh's materialId.
+    struct DrawGroup {
+        SdfPath materialId;
+        int start;
+        int count;
+    };
+
     class MeshData {
     public:
         SdfPath id;
@@ -104,6 +133,16 @@ public:
         VtValue edgeIndices;
         TfHashMap<TfToken, PrimvarData, TfToken::HashFunctor> primvars;
         std::vector<FaceVaryingChannel> faceVaryingChannels;
+
+        // Geom subsets recorded at sync time, in authored face indices.
+        // Extraction converts these into drawGroups; clients should use
+        // drawGroups for material binding and can treat these as
+        // provenance (e.g. mapping a draw group back to the subset prim).
+        std::vector<GeomSubsetData> geomSubsets;
+
+        // Per-material index buffer ranges; see DrawGroup. Populated only
+        // in extracted copies, and only for meshes with geom subsets.
+        std::vector<DrawGroup> drawGroups;
 
         // Instancing. If instancerId is non-empty this mesh is an instancing
         // prototype and should be drawn once per entry in instanceTransforms.

--- a/pxr/usdImaging/hydraPassthrough/renderData.h
+++ b/pxr/usdImaging/hydraPassthrough/renderData.h
@@ -333,6 +333,11 @@ public:
     /// data at a point in time. It is useful for extracting python
     /// copies that will exist and be cachable even after the render
     /// manager has performed its cleanup.
+    ///
+    /// In this and the other extracted copies, meshes with geom subsets
+    /// have their primitives reordered so each subset is a contiguous
+    /// range of the index buffer, published as per-material drawGroups;
+    /// see MeshData::drawGroups. Meshes without subsets are unchanged.
     RenderData ExtractRenderDataCopy() const;
 
     /// Extract a copy of the contained RenderData with all mesh primvars

--- a/pxr/usdImaging/hydraPassthrough/testenv/testHydraPassthroughGeomSubsets.py
+++ b/pxr/usdImaging/hydraPassthrough/testenv/testHydraPassthroughGeomSubsets.py
@@ -1,0 +1,267 @@
+#!/pxrpythonsubst
+
+import math
+import unittest
+
+from pxr import HydraPassthrough, Sdf, Usd, UsdGeom, UsdShade, Vt
+
+# The test plane: three quads and a triangle in a strip.
+#
+#   5---6---7---8
+#   |   |   |   | \
+#   |   |   |   |  9
+#   0---1---2---3 /
+#
+FACE_COUNTS = [4, 4, 4, 3]
+FACE_VERTEX_INDICES = [0, 1, 6, 5, 1, 2, 7, 6, 2, 3, 8, 7, 3, 4, 9]
+
+
+def create_plane_with_subsets(stage, scheme, subsets):
+    """Create the test plane with the given subdiv scheme, an st and a
+    uniform primvar whose values identify the authored face, a bound
+    material, and the given geom subsets.
+
+    subsets is a list of (name, face_indices, material_name_or_None)
+    tuples; material_name_or_None of None authors the subset without a
+    material binding.
+    """
+    materials = {}
+    for name in ('A', 'B', 'MeshMat'):
+        materials[name] = UsdShade.Material.Define(stage, '/Mats/' + name)
+
+    mesh = UsdGeom.Mesh.Define(stage, '/Plane')
+    mesh.CreateSubdivisionSchemeAttr(scheme)
+
+    points = [(x, y, 0) for y in (0, 1) for x in range(5)]
+    mesh.CreatePointsAttr(Vt.Vec3fArray(points))
+    mesh.CreateFaceVertexCountsAttr(Vt.IntArray(FACE_COUNTS))
+    mesh.CreateFaceVertexIndicesAttr(Vt.IntArray(FACE_VERTEX_INDICES))
+
+    primvars = UsdGeom.PrimvarsAPI(mesh)
+
+    # One uniform value per face: 10 * (face + 1).
+    uniform_primvar = primvars.CreatePrimvar(
+        'myUniform', Sdf.ValueTypeNames.FloatArray, UsdGeom.Tokens.uniform)
+    uniform_primvar.Set(
+        Vt.FloatArray([10.0 * (f + 1) for f in range(len(FACE_COUNTS))]))
+
+    # One st value per authored corner whose integer part is the authored
+    # face index. Values within a face span [face, face + 0.3], so any
+    # value interpolated within the face still floors to the face index.
+    st = []
+    for face, count in enumerate(FACE_COUNTS):
+        st.extend((face + 0.1 * corner, 0.0) for corner in range(count))
+    st_primvar = primvars.CreatePrimvar(
+        'st', Sdf.ValueTypeNames.TexCoord2fArray, UsdGeom.Tokens.faceVarying)
+    st_primvar.Set(Vt.Vec2fArray(st))
+
+    UsdShade.MaterialBindingAPI.Apply(mesh.GetPrim()).Bind(
+        materials['MeshMat'])
+
+    for name, faces, material_name in subsets:
+        subset = UsdGeom.Subset.CreateGeomSubset(
+            mesh, name, UsdGeom.Tokens.face, Vt.IntArray(faces),
+            'materialBind')
+        if material_name is not None:
+            UsdShade.MaterialBindingAPI.Apply(subset.GetPrim()).Bind(
+                materials[material_name])
+
+    return mesh
+
+
+def render_and_extract(stage, refine_level=0):
+    """Render the stage and return (plain, deindexed, welded) copies."""
+    settings = HydraPassthrough.RenderSettings()
+    settings.refineLevel = refine_level
+    manager = HydraPassthrough.RenderManager()
+    manager.Initialize(settings)
+    try:
+        manager.Render(stage)
+        render_data = manager.GetRenderData()
+        return (render_data.ExtractRenderDataCopy(),
+                render_data.ExtractDeindexedRenderDataCopy(),
+                render_data.ExtractWeldedRenderDataCopy())
+    finally:
+        manager.Cleanup()
+
+
+def plane_path():
+    prefix = HydraPassthrough.RenderManager.GetSceneDelegateId()
+    return Sdf.Path(prefix.AppendPath('Plane'))
+
+
+def decode_faces(prim_params):
+    """primitiveParam entries -> authored face per fine primitive."""
+    faces = []
+    for entry in prim_params:
+        encoded = entry if isinstance(entry, int) else entry[0]
+        faces.append(encoded >> 2)
+    return faces
+
+
+class GeomSubsetsTestBase(unittest.TestCase):
+    def checkDrawGroups(self, mesh, expected_groups, prims_per_face,
+                        corners_per_prim):
+        """Check that the mesh's draw groups tile the index buffer in
+        order, bind the expected materials, have the sizes implied by
+        their faces, and contain only primitives of their faces.
+
+        expected_groups is a list of (material_suffix, face_indices).
+        """
+        groups = mesh.GetDrawGroups()
+        self.assertEqual(len(groups), len(expected_groups))
+
+        num_corners = len(mesh.GetFaceVertexIndices().GetValue())
+        cursor = 0
+        for group in groups:
+            self.assertEqual(group.start, cursor)
+            self.assertGreater(group.count, 0)
+            cursor += group.count
+        self.assertEqual(cursor, num_corners)
+
+        faces_per_prim = decode_faces(mesh.GetPrimitiveParams().GetValue())
+        self.assertEqual(len(faces_per_prim) * corners_per_prim, num_corners)
+
+        for group, (material_suffix, faces) in zip(groups, expected_groups):
+            self.assertTrue(
+                str(group.materialId).endswith(material_suffix),
+                f'group material {group.materialId} does not end with '
+                f'{material_suffix}')
+            expected_count = corners_per_prim * sum(
+                prims_per_face[face] for face in faces)
+            self.assertEqual(group.count, expected_count)
+
+            first_prim = group.start // corners_per_prim
+            end_prim = (group.start + group.count) // corners_per_prim
+            for prim in range(first_prim, end_prim):
+                self.assertIn(faces_per_prim[prim], faces)
+
+        return groups
+
+    def checkCornerValues(self, mesh, groups, expected_groups):
+        """In a single-index layout (deindexed or welded), st and
+        myUniform must resolve to a face of the group at every corner."""
+        indices = mesh.GetFaceVertexIndices().GetValue()
+        st = mesh.GetPrimvar('st').data.GetValue()
+        uniform = mesh.GetPrimvar('myUniform').data.GetValue()
+        for group, (_, faces) in zip(groups, expected_groups):
+            for corner in range(group.start, group.start + group.count):
+                st_face = math.floor(st[indices[corner]][0] + 1e-4)
+                self.assertIn(st_face, faces)
+                uniform_face = int(uniform[indices[corner]] / 10.0 - 1)
+                self.assertIn(uniform_face, faces)
+
+
+class TestGeomSubsets(GeomSubsetsTestBase):
+    # Subset A lists its faces out of order on purpose; face 1 is in no
+    # subset and falls to the remainder group.
+    SUBSETS = [('subsetA', [3, 0], 'A'), ('subsetB', [2], 'B')]
+    EXPECTED_GROUPS = [('Mats/A', [3, 0]), ('Mats/B', [2]),
+                       ('Mats/MeshMat', [1])]
+
+    def runCase(self, scheme, refine_level, prims_per_face,
+                corners_per_prim):
+        stage = Usd.Stage.CreateInMemory()
+        create_plane_with_subsets(stage, scheme, self.SUBSETS)
+        plain, deindexed, welded = render_and_extract(stage, refine_level)
+
+        # The subset materials arrived through normal material sync.
+        prefix = HydraPassthrough.RenderManager.GetSceneDelegateId()
+        for name in ('A', 'B', 'MeshMat'):
+            self.assertIsNotNone(
+                plain.GetMaterial(Sdf.Path(prefix.AppendPath('Mats/' + name))))
+
+        # The sync-time subset record round-trips, sanitized but in
+        # authored order.
+        mesh = plain.GetMesh(plane_path())
+        subsets = mesh.GetGeomSubsets()
+        self.assertEqual(len(subsets), 2)
+        self.assertTrue(str(subsets[0].id).endswith('subsetA'))
+        self.assertEqual(list(subsets[0].GetFaceIndices().GetValue()), [3, 0])
+        self.assertTrue(str(subsets[1].materialId).endswith('Mats/B'))
+
+        for copy in (plain, deindexed, welded):
+            mesh = copy.GetMesh(plane_path())
+            groups = self.checkDrawGroups(
+                mesh, self.EXPECTED_GROUPS, prims_per_face, corners_per_prim)
+            if copy is not plain:
+                self.checkCornerValues(mesh, groups, self.EXPECTED_GROUPS)
+
+    def test_Unrefined(self):
+        # Quads triangulate to two triangles, the triangle stays one;
+        # primitiveParam has one entry per triangle.
+        self.runCase(UsdGeom.Tokens.none, 0,
+                     prims_per_face=[2, 2, 2, 1], corners_per_prim=3)
+
+    def test_Refined(self):
+        # Catmull-clark level 1 refines a quad into four patches and the
+        # triangle into three; each patch is a tri-quad of six corners.
+        self.runCase(UsdGeom.Tokens.catmullClark, 1,
+                     prims_per_face=[4, 4, 4, 3], corners_per_prim=6)
+
+
+class TestGeomSubsetEdgeCases(GeomSubsetsTestBase):
+    PRIMS_PER_FACE = [2, 2, 2, 1]  # unrefined, used by all cases below
+
+    def extractPlane(self, subsets):
+        stage = Usd.Stage.CreateInMemory()
+        create_plane_with_subsets(stage, UsdGeom.Tokens.none, subsets)
+        plain, _, _ = render_and_extract(stage)
+        return plain.GetMesh(plane_path())
+
+    def test_NoSubsets(self):
+        mesh = self.extractPlane([])
+        self.assertEqual(mesh.GetGeomSubsets(), [])
+        self.assertEqual(mesh.GetDrawGroups(), [])
+        # And the mesh is untouched: triangulated in authored face order.
+        faces = decode_faces(mesh.GetPrimitiveParams().GetValue())
+        self.assertEqual(faces, sorted(faces))
+
+    def test_FullCoverage(self):
+        # Subsets cover every face, so there is no remainder group.
+        mesh = self.extractPlane(
+            [('subsetA', [1, 3], 'A'), ('subsetB', [0, 2], 'B')])
+        self.checkDrawGroups(
+            mesh, [('Mats/A', [1, 3]), ('Mats/B', [0, 2])],
+            self.PRIMS_PER_FACE, corners_per_prim=3)
+
+    def test_OutOfRangeFaceDropped(self):
+        # Sanitizing warns about face 17 and drops it from the subset;
+        # the valid face still forms its group.
+        mesh = self.extractPlane([('subsetA', [17, 2], 'A')])
+        subsets = mesh.GetGeomSubsets()
+        self.assertEqual(len(subsets), 1)
+        self.assertEqual(list(subsets[0].GetFaceIndices().GetValue()), [2])
+        self.checkDrawGroups(
+            mesh, [('Mats/A', [2]), ('Mats/MeshMat', [0, 1, 3])],
+            self.PRIMS_PER_FACE, corners_per_prim=3)
+
+    def test_DuplicateFaceFirstSubsetWins(self):
+        # Face 2 appears in both subsets; sanitizing warns but keeps it,
+        # and grouping assigns it to the first subset that lists it.
+        mesh = self.extractPlane(
+            [('subsetA', [2, 0], 'A'), ('subsetB', [2, 3], 'B')])
+        self.checkDrawGroups(
+            mesh, [('Mats/A', [2, 0]), ('Mats/B', [3]),
+                   ('Mats/MeshMat', [1])],
+            self.PRIMS_PER_FACE, corners_per_prim=3)
+
+    def test_SubsetWithoutOwnMaterial(self):
+        # A subset with no binding of its own inherits the mesh's material
+        # through normal binding resolution, so it is not dropped by
+        # sanitizing: it survives with the inherited material and forms
+        # its own group, bound the same as the remainder.
+        mesh = self.extractPlane(
+            [('subsetA', [0], 'A'), ('subsetNoMat', [2], None)])
+        subsets = mesh.GetGeomSubsets()
+        self.assertEqual(len(subsets), 2)
+        self.assertTrue(str(subsets[1].id).endswith('subsetNoMat'))
+        self.assertTrue(str(subsets[1].materialId).endswith('Mats/MeshMat'))
+        self.checkDrawGroups(
+            mesh, [('Mats/A', [0]), ('Mats/MeshMat', [2]),
+                   ('Mats/MeshMat', [1, 3])],
+            self.PRIMS_PER_FACE, corners_per_prim=3)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pxr/usdImaging/hydraPassthrough/wrapRenderData.cpp
+++ b/pxr/usdImaging/hydraPassthrough/wrapRenderData.cpp
@@ -230,6 +230,24 @@ namespace {
         return self.faceVaryingChannels;
     }
 
+    HydraPassthroughValueDescriptor _GetGeomSubsetFaceIndices(
+        const HydraPassthroughRenderData::GeomSubsetData &self)
+    {
+        return HydraPassthroughValueDescriptor(VtValue(self.faceIndices));
+    }
+
+    const std::vector<HydraPassthroughRenderData::GeomSubsetData> &_GetGeomSubsets(
+        const HydraPassthroughRenderData::MeshData &self)
+    {
+        return self.geomSubsets;
+    }
+
+    const std::vector<HydraPassthroughRenderData::DrawGroup> &_GetDrawGroups(
+        const HydraPassthroughRenderData::MeshData &self)
+    {
+        return self.drawGroups;
+    }
+
     const std::map<int, SdfPath> &_GetInstanceOriginPaths(
         const HydraPassthroughRenderData::SceneGraphInstancerData &self)
     {
@@ -325,6 +343,18 @@ wrapRenderData()
         .def("GetPrimvarNames", &_GetPrimvarNames)
         ;
 
+    class_<This::GeomSubsetData>("GeomSubsetData", no_init)
+        .def_readonly("id", &This::GeomSubsetData::id)
+        .def_readonly("materialId", &This::GeomSubsetData::materialId)
+        .def("GetFaceIndices", ::_GetGeomSubsetFaceIndices)
+        ;
+
+    class_<This::DrawGroup>("DrawGroup", no_init)
+        .def_readonly("materialId", &This::DrawGroup::materialId)
+        .def_readonly("start", &This::DrawGroup::start)
+        .def_readonly("count", &This::DrawGroup::count)
+        ;
+
     class_<This::MeshData>("MeshData", no_init)
         .def_readonly("id", &This::MeshData::id)
         .def_readonly("materialId", &This::MeshData::materialId)
@@ -337,6 +367,10 @@ wrapRenderData()
              return_value_policy<TfPySequenceToList>())
         .def("GetPrimvar", &_GetPrimvar,(arg("name")))
         .def("GetFaceVaryingChannels", &_GetFaceVaryingChannels,
+             return_value_policy<TfPySequenceToList>())
+        .def("GetGeomSubsets", &_GetGeomSubsets,
+             return_value_policy<TfPySequenceToList>())
+        .def("GetDrawGroups", &_GetDrawGroups,
              return_value_policy<TfPySequenceToList>())
 
         .def("GetPoints", ::_GetMeshPoints)


### PR DESCRIPTION
Analyzing the code in HdSt, it seems like we don't need the kind of processing they're doing. In that library a separate draw item is generated for each mesh subset, and subdivision of primvars needs to account for that. In our code we are not generating draw items directly, just the data needed, so I intend to return a contiguous array of vertex indices and an index range for geom subsets.

Later, at packaging time, this data can be used to reorder vertex indices into those contiguous arrays, and clients can use that to do partial binding, or to generate draw items if they need them.